### PR TITLE
added cgo env vars to build instructions

### DIFF
--- a/build.md
+++ b/build.md
@@ -7,7 +7,7 @@ go test --cover
 ## Build
 
 ```bash
-docker run --rm -v $PWD:/usr/src/myapp -w /usr/src/myapp -v /tmp/linux-go:/go golang:1.7 sh -c "go get -d -v -t && go build -v -o docker-flow-swarm-listener"
+docker run --rm -v $PWD:/usr/src/myapp -w /usr/src/myapp -v /tmp/linux-go:/go golang:1.7 sh -c "go get -d -v -t && CGO_ENABLED=0 GOOS=linux go build -v -o docker-flow-swarm-listener"
 
 docker build -t vfarcic/docker-flow-swarm-listener:latest .
 ```


### PR DESCRIPTION
Adding CGO_ENABLED=0 and GOOS=linux env vars to the build command documentation 

