### PR TITLE
Update variable names (local and ENV) to be more intuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Next, we'll create the `swarm-listener` service.
 docker service create --name swarm-listener \
     --network proxy \
     --mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock" \
-    -e DF_NOTIF_CREATE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/reconfigure \
-    -e DF_NOTIF_REMOVE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/remove \
+    -e DF_NOTIFY_CREATE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/reconfigure \
+    -e DF_NOTIFY_REMOVE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/remove \
     --constraint 'node.role==manager' \
     vfarcic/docker-flow-swarm-listener
 ```
 
-The service is attached to the proxy network (just as the `proxy` service), mounts the Docker socket, and declares the environment variables `DF_NOTIF_CREATE_SERVICE_URL` and `DF_NOTIF_REMOVE_SERVICE_URL`. We'll see the purpose of the variables soon.
+The service is attached to the proxy network (just as the `proxy` service), mounts the Docker socket, and declares the environment variables `DF_NOTIFY_CREATE_SERVICE_URL` and `DF_NOTIFY_REMOVE_SERVICE_URL`. We'll see the purpose of the variables soon.
 
 Now we can deploy a service that will trigger the listener.
 
@@ -79,7 +79,7 @@ Starting iterations
 Sending a service created notification to http://proxy:8080/v1/docker-flow-proxy/reconfigure?serviceName=go-demo&port=8080&servicePath=/demo
 ```
 
-As you can see, the listener detected that the `go-demo` service has the label `com.df.notify` and sent the notification request. The address of the notification request is the value of the environment variable `DF_NOTIF_CREATE_SERVICE_URL` declared in the `swarm-listener` service. The parameters are a combination of the service name and all the labels prefixed with `DF_`.
+As you can see, the listener detected that the `go-demo` service has the label `com.df.notify` and sent the notification request. The address of the notification request is the value of the environment variable `DF_NOTIFY_CREATE_SERVICE_URL` declared in the `swarm-listener` service. The parameters are a combination of the service name and all the labels prefixed with `DF_`.
 
 You might have seen few entries stating that the notification request failed and will be retried. *Docker Flow: Swarm Listener* has a built-in retry mechanism. As long as the output message does not start with `ERROR:`, the notification will reach the destination. Please see the [Environment Variables](#environment-variables) for more info.
 
@@ -109,9 +109,11 @@ The following environment variables can be used when creating the `swarm listene
 |Name               |Description                                               |Default Value|
 |-------------------|----------------------------------------------------------|-------------|
 |DF_DOCKER_HOST     |Path to the Docker socket                   |unix:///var/run/docker.sock|
-|DF_NOTIFICATION_URL|Deprecated in favour of DF_NOTIF_* variables              |             |
-|DF_NOTIF_CREATE_SERVICE_URL|The URL that will be used to send notification requests when a service is created||
-|DF_NOTIF_REMOVE_SERVICE_URL|The URL that will be used to send notification requests when a service is removed||
+|DF_NOTIFICATION_URL|Deprecated in favour of DF_NOTIFY_* variables              |             |
+|DF_NOTIF_CREATE_SERVICE_URL|Deprecated in favor of DY_NOTIFY_* variables||
+|DF_NOTIF_REMOVE_SERVICE_URL|Deprecated in favor of DF_NOTIFY_* variables||
+|DF_NOTIFY_CREATE_SERVICE_URL|The URL that will be used to send notification requests when a service is created||
+|DF_NOTIFY_REMOVE_SERVICE_URL|The URL that will be used to send notification requests when a service is removed||
 |DF_INTERVAL        |Interval (in seconds) between service discovery requests  |5            |
 |DF_RETRY           |Number of notification request retries                    |10           |
 |DF_RETRY_INTERVAL  |Interval (in seconds) between notification request retries|5            |

--- a/build.md
+++ b/build.md
@@ -41,8 +41,8 @@ docker network create --driver overlay proxy
 docker service create --name swarm-listener \
     --network proxy \
     --mount "type=bind,source=/var/run/docker.sock,target=/var/run/docker.sock" \
-    -e DF_NOTIF_CREATE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/reconfigure \
-    -e DF_NOTIF_REMOVE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/remove \
+    -e DF_NOTIFY_CREATE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/reconfigure \
+    -e DF_NOTIFY_REMOVE_SERVICE_URL=http://proxy:8080/v1/docker-flow-proxy/remove \
     vfarcic/docker-flow-swarm-listener:beta
 
 docker service create --name go-demo-db \

--- a/service.go
+++ b/service.go
@@ -169,7 +169,7 @@ func (m *Service) NotifyServicesRemove(services []string, retries, interval int)
 	return nil
 }
 
-func NewService(host, notifCreateServiceUrl, notifRemoveServiceUrl string) *Service {
+func NewService(host, notifyCreateServiceUrl, notifyRemoveServiceUrl string) *Service {
 	defaultHeaders := map[string]string{"User-Agent": "engine-api-cli-1.0"}
 	dc, err := client.NewClient(host, "v1.22", nil, defaultHeaders)
 	if err != nil {
@@ -177,8 +177,8 @@ func NewService(host, notifCreateServiceUrl, notifRemoveServiceUrl string) *Serv
 	}
 	return &Service{
 		Host: host,
-		NotifCreateServiceUrl: notifCreateServiceUrl,
-		NotifRemoveServiceUrl: notifRemoveServiceUrl,
+		NotifCreateServiceUrl: notifyCreateServiceUrl,
+		NotifRemoveServiceUrl: notifyRemoveServiceUrl,
 		Services:              make(map[string]bool),
 		DockerClient:          dc,
 	}
@@ -186,16 +186,25 @@ func NewService(host, notifCreateServiceUrl, notifRemoveServiceUrl string) *Serv
 
 func NewServiceFromEnv() *Service {
 	host := "unix:///var/run/docker.sock"
-	if len(os.Getenv("DF_DOCKER_HOST")) > 0 {
+        notifyCreateServiceUrl := os.Getenv("DF_NOTIFY_CREATE_SERVICE_URL")
+        notifyRemoveServiceUrl := os.Getenv("DF_NOTIFY_REMOVE_SERVICE_URL")
+
+	if len(notifyCreateServiceUrl) > 0 {
 		host = os.Getenv("DF_DOCKER_HOST")
 	}
-	notifCreateServiceUrl := os.Getenv("DF_NOTIF_CREATE_SERVICE_URL")
-	if len(notifCreateServiceUrl) == 0 {
-		notifCreateServiceUrl = os.Getenv("DF_NOTIFICATION_URL")
-	}
-	notifRemoveServiceUrl := os.Getenv("DF_NOTIF_REMOVE_SERVICE_URL")
-	if len(notifRemoveServiceUrl) == 0 {
-		notifRemoveServiceUrl = os.Getenv("DF_NOTIFICATION_URL")
-	}
-	return NewService(host, notifCreateServiceUrl, notifRemoveServiceUrl)
+        if len(os.Getenv("DF_NOTIFY_CREATE_SERVICE_URL")) > 0 {
+                notifyCreateServiceUrl = os.Getenv("DF_NOTIFY_CREATE_SERVICE_URL")
+        } else if len(os.Getenv("DF_NOTIF_CREATE_SERVICE_URL")) > 0 {
+                notifyCreateServiceUrl = os.Getenv("DF_NOTIF_CREATE_SERVICE_URL")
+        } else {
+                notifyCreateServiceUrl = os.Getenv("DF_NOTIFICATION_URL")   
+        } 
+        if len(notifyRemoveServiceUrl) > 0 {
+                notifyRemoveServiceUrl = os.Getenv("DF_NOTIFY_REMOVE_SERVICE_URL")
+        } else if len(os.Getenv("DF_NOTIF_REMOVE_SERVICE_URL")) > 0 {
+                notifyRemoveServiceUrl = os.Getenv("DF_NOTIF_REMOVE_SERVICE_URL")
+        } else {
+                notifyRemoveServiceUrl = os.Getenv("DF_NOTIFICATION_URL")
+        }
+	return NewService(host, notifyCreateServiceUrl, notifyRemoveServiceUrl)
 }

--- a/service_test.go
+++ b/service_test.go
@@ -286,10 +286,10 @@ func (s *ServiceTestSuite) Test_NewServiceFromEnv_SetsNotifUrl() {
 }
 
 func (s *ServiceTestSuite) Test_NewServiceFromEnv_SetsNotifCreateServiceUrl() {
-	host := os.Getenv("DF_NOTIF_CREATE_SERVICE_URL")
-	defer func() { os.Setenv("DF_NOTIF_CREATE_SERVICE_URL", host) }()
+	host := os.Getenv("DF_NOTIFY_CREATE_SERVICE_URL")
+	defer func() { os.Setenv("DF_NOTIFY_CREATE_SERVICE_URL", host) }()
 	expected := "this-is-a-notification-url"
-	os.Setenv("DF_NOTIF_CREATE_SERVICE_URL", expected)
+	os.Setenv("DF_NOTIFY_CREATE_SERVICE_URL", expected)
 
 	service := NewServiceFromEnv()
 
@@ -297,10 +297,10 @@ func (s *ServiceTestSuite) Test_NewServiceFromEnv_SetsNotifCreateServiceUrl() {
 }
 
 func (s *ServiceTestSuite) Test_NewServiceFromEnv_SetsNotifRemoveServiceUrl() {
-	host := os.Getenv("DF_NOTIF_REMOVE_SERVICE_URL")
-	defer func() { os.Setenv("DF_NOTIF_REMOVE_SERVICE_URL", host) }()
+	host := os.Getenv("DF_NOTIFY_REMOVE_SERVICE_URL")
+	defer func() { os.Setenv("DF_NOTIFY_REMOVE_SERVICE_URL", host) }()
 	expected := "this-is-a-notification-url"
-	os.Setenv("DF_NOTIF_REMOVE_SERVICE_URL", expected)
+	os.Setenv("DF_NOTIFY_REMOVE_SERVICE_URL", expected)
 
 	service := NewServiceFromEnv()
 


### PR DESCRIPTION
rename ENV variable names from DF_NOTIF_* (short for 'notification') to DF_NOTIFY_*
  update local variables to be more intuitive and inline with new ENV names
    "notifCreateServiceUrl" renamed to "notifyCreateServiceUrl"
    "notifRemoveServiceUrl" renamed to "notifyRemoveServiceUrl"

 Changes to be committed:
	modified:   README.md
	modified:   build.md
	modified:   service.go
	modified:   service_test.go