### PR TITLE
/v1/docker-flow-swarm-listener/get-services endpoint that gets whole …

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"./service"
+	"encoding/json"
 	"net/http"
 )
 
@@ -34,6 +35,17 @@ func (m *Serve) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		go m.Notification.ServicesCreate(services, 10, 5)
 		// TODO: Add response message
 		w.WriteHeader(http.StatusOK)
+	case "/v1/docker-flow-swarm-listener/get-services":
+		services, _ := m.Service.GetServices()
+		parameters := m.Service.GetServicesParameters(services)
+		bytes, error := json.Marshal(parameters)
+		if error != nil {
+			logPrintf("ERROR: Unable to prepare response: %s", error)
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.Write(bytes)
+			w.WriteHeader(http.StatusOK)
+		}
 	default:
 		w.WriteHeader(http.StatusNotFound)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -24,6 +24,25 @@ type Servicer interface {
 	GetServices() (*[]swarm.Service, error)
 	GetNewServices(services *[]swarm.Service) (*[]swarm.Service, error)
 	GetRemovedServices(services *[]swarm.Service) *[]string
+	GetServicesParameters(services *[]swarm.Service) *[]map[string]string
+}
+
+
+func (m *Service) GetServicesParameters(services *[]swarm.Service) *[]map[string]string {
+	var parameters = []map[string]string{}
+	for _, s := range *services {
+		if _, ok := s.Spec.Labels[os.Getenv("DF_NOTIFY_LABEL")]; ok {
+			var sParams = make(map[string]string)
+			sParams["serviceName"] = s.Spec.Name
+			for k, v := range s.Spec.Labels {
+				if strings.HasPrefix(k, "com.df") && k != os.Getenv("DF_NOTIFY_LABEL") {
+					sParams[strings.TrimPrefix(k, "com.df.")] = v
+				}
+			}
+			parameters = append(parameters, sParams)
+		}
+	}
+	return &parameters
 }
 
 func (m *Service) GetServices() (*[]swarm.Service, error) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -166,6 +166,34 @@ func (s *ServiceTestSuite) Test_GetRemovedServices_ReturnsNamesOfRemovedServices
 	s.Contains(*actual, "removed-service-2")
 }
 
+// GetServicesParameters
+
+func (s *ServiceTestSuite) Test_GetRemovedServices_GetServicesParameters() {
+	service := NewService("unix:///var/run/docker.sock")
+	srvs := []swarm.Service{
+		{
+			Spec: swarm.ServiceSpec{
+				Annotations: swarm.Annotations{
+					Name: "demo",
+					Labels: map[string]string{
+						"com.df.notify":      "true",
+						"com.df.servicePath": "/demo",
+						"com.df.distribute":  "true",
+
+					},
+				},
+			},
+		},
+	}
+	paramsList := service.GetServicesParameters(&srvs)
+	expected := []map[string]string{
+		{"serviceName":        "demo",
+			"servicePath": "/demo",
+			"distribute":  "true", },
+	}
+	s.Equal(&expected, paramsList)
+}
+
 // NewService
 
 func (s *ServiceTestSuite) Test_NewService_SetsHost() {


### PR DESCRIPTION
/v1/docker-flow-swarm-listener/get-services endpoint.
To be used for fix of https://github.com/vfarcic/docker-flow-proxy/issues/165.

Get all applicabble services state at once.