### PR TITLE
Uses Docker service events

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,43 +3,74 @@ package main
 import (
 	"./metrics"
 	"./service"
-	"time"
 )
 
 func main() {
 	logPrintf("Starting Docker Flow: Swarm Listener")
 	s := service.NewServiceFromEnv()
 	n := service.NewNotificationFromEnv()
+	el := service.NewEventListenerFromEnv()
 	serve := NewServe(s, n)
 	go serve.Run()
 
 	args := getArgs()
-	if len(n.CreateServiceAddr) > 0 {
-		logPrintf("Starting iterations")
-		for {
-			allServices, err := s.GetServices()
-			if err != nil {
-				metrics.RecordError("GetServices")
+	if len(n.CreateServiceAddr) == 0 {
+		return
+	}
+
+	logPrintf("Sending create for all services")
+	allServices, err := s.GetServices()
+	if err != nil {
+		metrics.RecordError("GetServices")
+	}
+
+	newServices, err := s.GetNewServices(allServices)
+	if err != nil {
+		metrics.RecordError("GetNewServices")
+	}
+	err = n.ServicesCreate(
+		newServices,
+		args.Retry,
+		args.RetryInterval,
+	)
+	if err != nil {
+		metrics.RecordError("ServicesCreate")
+	}
+
+	logPrintf("Start listening to docker service events")
+	events, errs := el.ListenForEvents()
+	for {
+		select {
+		case event := <-events:
+			if event.Action == "create" || event.Action == "update" {
+				eventServices, err := s.GetServicesFromID(event.ServiceID)
+				if err != nil {
+					metrics.RecordError("GetServicesFromID")
+				}
+				newServices, err := s.GetNewServices(eventServices)
+				if err != nil {
+					metrics.RecordError("GetNewServices")
+				}
+				err = n.ServicesCreate(
+					newServices,
+					args.Retry,
+					args.RetryInterval,
+				)
+				if err != nil {
+					metrics.RecordError("ServicesCreate")
+				}
+
+			} else if event.Action == "remove" {
+				err = n.ServicesRemove(&[]string{event.ServiceID}, args.Retry, args.RetryInterval)
+				metrics.RecordService(len(service.CachedServices))
+				if err != nil {
+					metrics.RecordError("ServicesRemove")
+				}
 			}
-			newServices, err := s.GetNewServices(allServices)
-			if err != nil {
-				metrics.RecordError("GetNewServices")
-			}
-			err = n.ServicesCreate(
-				newServices,
-				args.Retry,
-				args.RetryInterval,
-			)
-			if err != nil {
-				metrics.RecordError("ServicesCreate")
-			}
-			removedServices := s.GetRemovedServices(allServices)
-			err = n.ServicesRemove(removedServices, args.Retry, args.RetryInterval)
-			metrics.RecordService(len(service.CachedServices))
-			if err != nil {
-				metrics.RecordError("ServicesRemove")
-			}
-			time.Sleep(time.Second * time.Duration(args.Interval))
+		case <-errs:
+			metrics.RecordError("ListenForEvents")
+			// Restart listening for events
+			events, errs = el.ListenForEvents()
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 		return
 	}
 
-	logPrintf("Sending create for all services")
+	logPrintf("Sending notifications for running services")
 	allServices, err := s.GetServices()
 	if err != nil {
 		metrics.RecordError("GetServices")

--- a/serve_test.go
+++ b/serve_test.go
@@ -255,11 +255,6 @@ func (m *ServicerMock) GetNewServices(services *[]service.SwarmService) (*[]serv
 	return args.Get(0).(*[]service.SwarmService), args.Error(1)
 }
 
-func (m *ServicerMock) GetRemovedServices(services *[]service.SwarmService) *[]string {
-	args := m.Called(services)
-	return args.Get(0).(*[]string)
-}
-
 func (m *ServicerMock) GetServicesParameters(services *[]service.SwarmService) *[]map[string]string {
 	args := m.Called(services)
 	return args.Get(0).(*[]map[string]string)
@@ -272,9 +267,6 @@ func getServicerMock(skipMethod string) *ServicerMock {
 	}
 	if !strings.EqualFold("GetNewServices", skipMethod) {
 		mockObj.On("GetNewServices", mock.Anything).Return([]service.SwarmService{}, nil)
-	}
-	if !strings.EqualFold("GetRemovedServices", skipMethod) {
-		mockObj.On("GetRemovedServices", mock.Anything).Return(&[]string{})
 	}
 	if !strings.EqualFold("GetServicesParameters", skipMethod) {
 		mockObj.On("GetServicesParameters", mock.Anything).Return(&[]map[string]string{})

--- a/service/eventlistener.go
+++ b/service/eventlistener.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"os"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+// EventListener listens for docker service events
+type EventListener struct {
+	*client.Client
+}
+
+// Event contains information about docker service events
+type Event struct {
+	Action    string
+	ServiceID string
+}
+
+// NewEventListener returns a new instance of the `EventListener` structure
+func NewEventListener(host string) *EventListener {
+	defaultHeaders := map[string]string{"User-Agent": "engine-api-cli-1.0"}
+	dc, err := client.NewClient(host, dockerApiVersion, nil, defaultHeaders)
+	if err != nil {
+		logPrintf(err.Error())
+	}
+	return &EventListener{dc}
+}
+
+// NewEventListenerFromEnv returns a new instance of the `EventListener` structure using environment variable `DF_DOCKER_HOST` for the host
+func NewEventListenerFromEnv() *EventListener {
+	host := "unix:///var/run/docker.sock"
+	if len(os.Getenv("DF_DOCKER_HOST")) > 0 {
+		host = os.Getenv("DF_DOCKER_HOST")
+	}
+	return NewEventListener(host)
+}
+
+// ListenForEvents returns a stream of Events
+func (s *EventListener) ListenForEvents() (<-chan Event, <-chan error) {
+
+	events := make(chan Event)
+	errs := make(chan error, 1)
+	started := make(chan struct{})
+
+	go func() {
+		defer close(errs)
+		filter := filters.NewArgs()
+		filter.Add("type", "service")
+		eventStream, eventErrors := s.Events(
+			context.Background(),
+			types.EventsOptions{Filters: filter},
+		)
+
+		close(started)
+		for {
+			select {
+			case msg := <-eventStream:
+				events <- Event{
+					Action:    msg.Action,
+					ServiceID: msg.Actor.ID,
+				}
+			case err := <-eventErrors:
+				logPrintf("%v", err)
+				errs <- err
+				return
+			}
+		}
+
+	}()
+	<-started
+
+	return events, errs
+}

--- a/service/eventlistener_test.go
+++ b/service/eventlistener_test.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type EventListenerTestSuite struct {
+	suite.Suite
+	serviceName string
+}
+
+func TestEventListenerUnitTestSuite(t *testing.T) {
+	s := new(EventListenerTestSuite)
+	s.serviceName = "my-service"
+	logPrintfOrig := logPrintf
+	defer func() {
+		logPrintf = logPrintfOrig
+		os.Unsetenv("DF_NOTIFY_LABEL")
+	}()
+	logPrintf = func(format string, v ...interface{}) {}
+	os.Setenv("DF_NOTIFY_LABEL", "com.df.notify")
+
+	suite.Run(t, s)
+}
+
+func (s *EventListenerTestSuite) Test_ListenForEvents_IncorrectSocket() {
+	eventListener := NewEventListener("unix:///this/socket/does/not/exist")
+	_, errs := eventListener.ListenForEvents()
+
+	err := s.GetChannelError(errs)
+	s.Error(err)
+}
+
+func (s *EventListenerTestSuite) Test_ListenForEvents_CreateService() {
+	eventListener := NewEventListener("unix:///var/run/docker.sock")
+	service := NewService("unix:///var/run/docker.sock")
+
+	events, errs := eventListener.ListenForEvents()
+
+	defer func() {
+		removeTestService("util-el-1")
+	}()
+	createTestService("util-el-1", []string{"com.df.notify=true", "com.df.servicePath=/demo", "com.df.distribute=true"}, "", "")
+
+	event, err := s.GetChannelEvent(events, errs)
+
+	s.Require().NoError(err)
+
+	s.Equal("create", event.Action)
+
+	serviceID := event.ServiceID
+	s.Require().NotEmpty(serviceID)
+
+	eventServices, err := service.GetServicesFromID(serviceID)
+	s.Require().NoError(err)
+	s.Require().NotNil(eventServices)
+	s.Require().Len(*eventServices, 1)
+
+	eventService := (*eventServices)[0]
+
+	s.Equal("util-el-1", eventService.Spec.Name)
+	s.Nil(eventService.NodeInfo)
+}
+
+func (s *EventListenerTestSuite) Test_ListenForEvents_CreateService_WithNodeInfo() {
+
+	eventListener := NewEventListener("unix:///var/run/docker.sock")
+	service := NewService("unix:///var/run/docker.sock")
+
+	events, errs := eventListener.ListenForEvents()
+
+	defer func() {
+		os.Unsetenv("DF_INCLUDE_NODE_IP_INFO")
+		removeTestService("util-el-1")
+		removeTestNetwork("util-el-network")
+	}()
+	os.Setenv("DF_INCLUDE_NODE_IP_INFO", "true")
+	createTestNetwork("util-el-network")
+	createTestService("util-el-1",
+		[]string{"com.df.notify=true", "com.df.scrapeNetwork=util-el-network", "com.df.distribute=true"},
+		"", "util-el-network")
+
+	event, err := s.GetChannelEvent(events, errs)
+
+	s.Require().NoError(err)
+
+	s.Equal("create", event.Action)
+
+	serviceID := event.ServiceID
+	s.Require().NotEmpty(serviceID)
+
+	eventServices, err := service.GetServicesFromID(serviceID)
+	s.Require().NoError(err)
+	s.Require().NotNil(eventServices)
+	s.Require().Len(*eventServices, 1)
+
+	eventService := (*eventServices)[0]
+
+	s.Equal("util-el-1", eventService.Spec.Name)
+	s.NotNil(eventService.NodeInfo)
+}
+func (s *EventListenerTestSuite) Test_ListenForEvents_RemoveService() {
+	eventListener := NewEventListener("unix:///var/run/docker.sock")
+	service := NewService("unix:///var/run/docker.sock")
+
+	events, errs := eventListener.ListenForEvents()
+
+	defer func() {
+		removeTestService("util-el-1")
+	}()
+	createTestService("util-el-1", []string{"com.df.notify=true", "com.df.servicePath=/demo", "com.df.distribute=true"}, "", "")
+
+	// Check create event action
+	event, err := s.GetChannelEvent(events, errs)
+	s.Require().NoError(err)
+	s.Equal("create", event.Action)
+
+	serviceID := event.ServiceID
+	s.Require().NotEmpty(serviceID)
+
+	eventServices, err := service.GetServicesFromID(serviceID)
+	s.Require().NoError(err)
+	s.Require().NotNil(eventServices)
+	s.Require().Len(*eventServices, 1)
+	eventService := (*eventServices)[0]
+
+	removeTestService("util-el-1")
+	event, err = s.GetChannelEvent(events, errs)
+
+	s.Require().NoError(err)
+	s.Equal("remove", event.Action)
+
+	serviceID = event.ServiceID
+	s.NotEmpty(serviceID)
+	s.Equal(eventService.ID, serviceID)
+}
+
+func (s *EventListenerTestSuite) GetChannelError(errs <-chan error) error {
+	timeOut := time.NewTimer(time.Second * 5).C
+	for {
+		select {
+		case err := <-errs:
+			return err
+		case <-timeOut:
+			return fmt.Errorf("Timeout")
+		}
+	}
+}
+
+func (s *EventListenerTestSuite) GetChannelEvent(events <-chan Event, errs <-chan error) (*Event, error) {
+	timeOut := time.NewTimer(time.Second * 5).C
+	for {
+		select {
+		case event := <-events:
+			return &event, nil
+		case err := <-errs:
+			return nil, err
+		case <-timeOut:
+			return nil, fmt.Errorf("Timeout")
+		}
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -72,7 +72,7 @@ func (m *Service) GetNewServices(services *[]SwarmService) (*[]SwarmService, err
 	for _, s := range *services {
 		if tmpUpdatedAt.Nanosecond() == 0 || s.Meta.UpdatedAt.After(tmpUpdatedAt) {
 			updated := false
-			if service, ok := CachedServices[s.Spec.Name]; ok {
+			if service, ok := CachedServices[s.ID]; ok {
 				if m.isUpdated(s, service) {
 					updated = true
 				}
@@ -81,7 +81,7 @@ func (m *Service) GetNewServices(services *[]SwarmService) (*[]SwarmService, err
 			}
 			if updated {
 				newServices = append(newServices, s)
-				CachedServices[s.Spec.Name] = s
+				CachedServices[s.ID] = s
 				if m.ServiceLastUpdatedAt.Before(s.Meta.UpdatedAt) {
 					m.ServiceLastUpdatedAt = s.Meta.UpdatedAt
 				}
@@ -98,7 +98,7 @@ func (m *Service) GetRemovedServices(services *[]SwarmService) *[]string {
 		tmpMap[k] = v
 	}
 	for _, v := range *services {
-		if _, ok := CachedServices[v.Spec.Name]; ok && !hasZeroReplicas(&v) {
+		if _, ok := CachedServices[v.ID]; ok && !hasZeroReplicas(&v) {
 			delete(tmpMap, v.Spec.Name)
 		}
 	}
@@ -107,6 +107,30 @@ func (m *Service) GetRemovedServices(services *[]SwarmService) *[]string {
 		rs = append(rs, k)
 	}
 	return &rs
+}
+
+// GetServicesFromID returns service associated with serviceID
+func (m *Service) GetServicesFromID(serviceID string) (*[]SwarmService, error) {
+	filter := filters.NewArgs()
+	filter.Add("label", fmt.Sprintf("%s=true", os.Getenv("DF_NOTIFY_LABEL")))
+	filter.Add("id", serviceID)
+	services, err := m.DockerClient.ServiceList(
+		context.Background(),
+		types.ServiceListOptions{Filters: filter},
+	)
+	if err != nil {
+		return &[]SwarmService{}, err
+	}
+
+	swarmServices := []SwarmService{}
+	for _, s := range services {
+		ss := SwarmService{s, nil}
+		if strings.EqualFold(os.Getenv("DF_INCLUDE_NODE_IP_INFO"), "true") {
+			ss.NodeInfo = m.getNodeInfo(ss)
+		}
+		swarmServices = append(swarmServices, ss)
+	}
+	return &swarmServices, nil
 }
 
 // NewService returns a new instance of the `Service` structure

--- a/service/service.go
+++ b/service/service.go
@@ -26,7 +26,6 @@ type Service struct {
 type Servicer interface {
 	GetServices() (*[]SwarmService, error)
 	GetNewServices(services *[]SwarmService) (*[]SwarmService, error)
-	GetRemovedServices(services *[]SwarmService) *[]string
 	GetServicesParameters(services *[]SwarmService) *[]map[string]string
 }
 
@@ -89,24 +88,6 @@ func (m *Service) GetNewServices(services *[]SwarmService) (*[]SwarmService, err
 		}
 	}
 	return &newServices, nil
-}
-
-// GetRemovedServices returns services that were removed from the cluster
-func (m *Service) GetRemovedServices(services *[]SwarmService) *[]string {
-	tmpMap := make(map[string]SwarmService)
-	for k, v := range CachedServices {
-		tmpMap[k] = v
-	}
-	for _, v := range *services {
-		if _, ok := CachedServices[v.ID]; ok && !hasZeroReplicas(&v) {
-			delete(tmpMap, v.Spec.Name)
-		}
-	}
-	rs := []string{}
-	for k := range tmpMap {
-		rs = append(rs, k)
-	}
-	return &rs
 }
 
 // GetServicesFromID returns service associated with serviceID

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -322,40 +322,9 @@ func (s *ServiceTestSuite) Test_GetNewServices_AddsUpdatedServices_WhenReplicasA
 	s.Nil(actualService.NodeInfo)
 }
 
-// GetRemovedServices
-
-func (s *ServiceTestSuite) Test_GetRemovedServices_ReturnsNamesOfRemovedServices() {
-	service := NewService("unix:///var/run/docker.sock")
-	services, _ := service.GetServices()
-	CachedServices["removed-service-1"] = SwarmService{}
-	CachedServices["removed-service-2"] = SwarmService{}
-
-	actual := service.GetRemovedServices(services)
-
-	s.Equal(2, len(*actual))
-	s.Contains(*actual, "removed-service-1")
-	s.Contains(*actual, "removed-service-2")
-}
-
-func (s *ServiceTestSuite) Test_GetRemovedServices_AddsServicesWithZeroReplicas() {
-	service := NewService("unix:///var/run/docker.sock")
-	services, _ := service.GetServices()
-	CachedServices["util-1"] = SwarmService{}
-	for _, s := range *services {
-		if s.Spec.Mode.Replicated != nil {
-			replicas := uint64(0)
-			s.Spec.Mode.Replicated.Replicas = &replicas
-		}
-	}
-	actual := service.GetRemovedServices(services)
-
-	s.Equal(1, len(*actual))
-	s.Contains(*actual, "util-1")
-}
-
 // GetServicesParameters
 
-func (s *ServiceTestSuite) Test_GetRemovedServices_GetServicesParameters() {
+func (s *ServiceTestSuite) Test_GetServicesParameters() {
 	service := NewService("unix:///var/run/docker.sock")
 	replicas := uint64(1)
 	mode := swarm.ServiceMode{
@@ -433,7 +402,7 @@ func (s *ServiceTestSuite) Test_GetServiceParametersWithNodeInfo() {
 	s.True(nodeInfo.Equal(paramNodeInfo))
 }
 
-func (s *ServiceTestSuite) Test_GetRemovedServices_IgnoresThoseScaledToZero() {
+func (s *ServiceTestSuite) Test_GetServicesParameters_IgnoresThoseScaledToZero() {
 	service := NewService("unix:///var/run/docker.sock")
 	replicas := uint64(0)
 	mode := swarm.ServiceMode{


### PR DESCRIPTION
Closes #36.

1. I converted the keys to `CachedServices` to be the service IDs instead of the service names, since the Docker Events API returns service IDs for `create`, `remove` or `update` actions. 

2. The Events API provides the service ID for removed services, thus `service.GetRemovedServices` can be removed.

3. `notification.ServicesRemove` accepts service IDs instead of service names.