### PR TITLE
API: Wait for tasks to converge

### DIFF
--- a/service/eventnodelistener.go
+++ b/service/eventnodelistener.go
@@ -66,7 +66,7 @@ func (s NodeListener) ListenForNodeEvents(
 
 }
 
-// validEventNode returns false when event is valid (should be passed through)
+// validEventNode returns true when event is valid (should be passed through)
 // this will still allow through 4-5 events from changing a worker node
 // to a manager node or vise versa.
 func (s NodeListener) validEventNode(msg events.Message) bool {

--- a/service/minify_test.go
+++ b/service/minify_test.go
@@ -110,10 +110,10 @@ func (s *MinifyUnitTestSuite) Test_MinifySwarmService_Global() {
 		},
 		Global:   true,
 		Replicas: uint64(0),
-		NodeInfo: &nodeSet,
+		NodeInfo: nodeSet,
 	}
 
-	ss := SwarmService{service, &nodeSet}
+	ss := SwarmService{service, nodeSet}
 	ssMini := MinifySwarmService(ss, "com.df.notify", "com.docker.stack.namespace")
 
 	s.Equal(expectMini, ssMini)
@@ -159,10 +159,10 @@ func (s *MinifyUnitTestSuite) Test_MinifySwarmService_Replicas() {
 		},
 		Global:   false,
 		Replicas: uint64(3),
-		NodeInfo: &nodeSet,
+		NodeInfo: nodeSet,
 	}
 
-	ss := SwarmService{service, &nodeSet}
+	ss := SwarmService{service, nodeSet}
 	ssMini := MinifySwarmService(ss, "com.df.notify", "com.docker.stack.namespace")
 
 	s.Equal(expectMini, ssMini)

--- a/service/service.go
+++ b/service/service.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -22,15 +24,18 @@ type SwarmServiceClient struct {
 	FilterLabel    string
 	FilterKey      string
 	ScrapeNetLabel string
+	Log            *log.Logger
 }
 
 // NewSwarmServiceClient creates a `SwarmServiceClient`
-func NewSwarmServiceClient(c *client.Client, filterLabel, scrapNetLabel string) *SwarmServiceClient {
+func NewSwarmServiceClient(c *client.Client, filterLabel, scrapNetLabel string, logger *log.Logger) *SwarmServiceClient {
 	key := strings.SplitN(filterLabel, "=", 2)[0]
 	return &SwarmServiceClient{DockerClient: c,
 		FilterLabel:    filterLabel,
 		FilterKey:      key,
-		ScrapeNetLabel: scrapNetLabel}
+		ScrapeNetLabel: scrapNetLabel,
+		Log:            logger,
+	}
 }
 
 // SwarmServiceInspect returns `SwarmService` from its ID
@@ -49,7 +54,12 @@ func (c SwarmServiceClient) SwarmServiceInspect(serviceID string, includeNodeIPI
 
 	ss := SwarmService{service, nil}
 	if includeNodeIPInfo {
-		ss.NodeInfo = c.getNodeInfo(service)
+		nodeInfo, err := c.getNodeInfo(context.Background(), service)
+		if err != nil {
+			c.Log.Printf("%v", err)
+		} else {
+			ss.NodeInfo = nodeInfo
+		}
 	}
 	return &ss, nil
 }
@@ -67,23 +77,28 @@ func (c SwarmServiceClient) SwarmServiceList(ctx context.Context, includeNodeIPI
 	for _, s := range services {
 		ss := SwarmService{s, nil}
 		if includeNodeIPInfo {
-			ss.NodeInfo = c.getNodeInfo(s)
+			nodeInfo, _ := c.getNodeInfo(ctx, s)
+			if err != nil {
+				c.Log.Printf("%v", err)
+			} else {
+				ss.NodeInfo = nodeInfo
+			}
 		}
 		swarmServices = append(swarmServices, ss)
 	}
 	return swarmServices, nil
 }
 
-func (c SwarmServiceClient) getNodeInfo(ss swarm.Service) *NodeIPSet {
+func (c SwarmServiceClient) getNodeInfo(ctx context.Context, ss swarm.Service) (*NodeIPSet, error) {
 
 	networkName, ok := ss.Spec.Labels[c.ScrapeNetLabel]
 	if !ok {
-		return nil
+		return nil, fmt.Errorf("NodeInfo %s label is not defined for service %s", c.ScrapeNetLabel, ss.Spec.Name)
 	}
 
-	taskList, err := c.getTaskList(ss.ID)
+	taskList, err := GetTaskList(ctx, c.DockerClient, ss.ID)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	nodeInfo := NodeIPSet{}
@@ -116,16 +131,7 @@ func (c SwarmServiceClient) getNodeInfo(ss swarm.Service) *NodeIPSet {
 	}
 
 	if nodeInfo.Cardinality() == 0 {
-		return nil
+		return nil, nil
 	}
-	return &nodeInfo
-}
-
-func (c SwarmServiceClient) getTaskList(serviceID string) ([]swarm.Task, error) {
-
-	filter := filters.NewArgs()
-	filter.Add("desired-state", "running")
-	filter.Add("service", serviceID)
-	return c.DockerClient.TaskList(
-		context.Background(), types.TaskListOptions{Filters: filter})
+	return &nodeInfo, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -89,7 +89,7 @@ func (c SwarmServiceClient) SwarmServiceList(ctx context.Context, includeNodeIPI
 	return swarmServices, nil
 }
 
-func (c SwarmServiceClient) getNodeInfo(ctx context.Context, ss swarm.Service) (*NodeIPSet, error) {
+func (c SwarmServiceClient) getNodeInfo(ctx context.Context, ss swarm.Service) (NodeIPSet, error) {
 
 	networkName, ok := ss.Spec.Labels[c.ScrapeNetLabel]
 	if !ok {
@@ -121,7 +121,7 @@ func (c SwarmServiceClient) getNodeInfo(ctx context.Context, ss swarm.Service) (
 		if nodeName, ok := nodeIPCache[task.NodeID]; ok {
 			nodeInfo.Add(nodeName, address)
 		} else {
-			node, _, err := c.DockerClient.NodeInspectWithRaw(context.Background(), task.NodeID)
+			node, _, err := c.DockerClient.NodeInspectWithRaw(ctx, task.NodeID)
 			if err != nil {
 				continue
 			}
@@ -133,5 +133,5 @@ func (c SwarmServiceClient) getNodeInfo(ctx context.Context, ss swarm.Service) (
 	if nodeInfo.Cardinality() == 0 {
 		return nil, nil
 	}
-	return &nodeInfo, nil
+	return nodeInfo, nil
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -92,7 +92,7 @@ func (s *SwarmServiceClientTestSuite) Test_SwarmServiceInspect_NodeInfo_OneRepli
 	s.Equal(s.Util1ID, util1Service.ID)
 	s.Require().NotNil(util1Service.NodeInfo)
 
-	nodeInfo := *util1Service.NodeInfo
+	nodeInfo := util1Service.NodeInfo
 	s.Require().Len(nodeInfo, 1)
 }
 
@@ -105,7 +105,7 @@ func (s *SwarmServiceClientTestSuite) Test_SwarmServiceInspect_NodeInfo_TwoRepli
 	s.Equal(s.Util4ID, util4Service.ID)
 	s.Require().NotNil(util4Service.NodeInfo)
 
-	nodeInfo := *util4Service.NodeInfo
+	nodeInfo := util4Service.NodeInfo
 	s.Require().Len(nodeInfo, 2)
 }
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,7 +1,9 @@
 package service
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"testing"
 	"time"
 
@@ -10,11 +12,13 @@ import (
 
 type SwarmServiceClientTestSuite struct {
 	suite.Suite
-	SClient *SwarmServiceClient
-	Util1ID string
-	Util2ID string
-	Util3ID string
-	Util4ID string
+	SClient  *SwarmServiceClient
+	Util1ID  string
+	Util2ID  string
+	Util3ID  string
+	Util4ID  string
+	Logger   *log.Logger
+	LogBytes *bytes.Buffer
 }
 
 func TestSwarmServiceClientTestSuite(t *testing.T) {
@@ -24,7 +28,11 @@ func TestSwarmServiceClientTestSuite(t *testing.T) {
 func (s *SwarmServiceClientTestSuite) SetupSuite() {
 	c, err := NewDockerClientFromEnv()
 	s.Require().NoError(err)
-	s.SClient = NewSwarmServiceClient(c, "com.df.notify=true", "com.df.scrapeNetwork")
+
+	s.LogBytes = new(bytes.Buffer)
+	s.Logger = log.New(s.LogBytes, "", 0)
+
+	s.SClient = NewSwarmServiceClient(c, "com.df.notify=true", "com.df.scrapeNetwork", s.Logger)
 
 	createTestOverlayNetwork("util-network")
 	createTestService("util-1", []string{"com.df.notify=true", "com.df.scrapeNetwork=util-network"}, false, "", "util-network")

--- a/service/servicecache_test.go
+++ b/service/servicecache_test.go
@@ -114,7 +114,7 @@ func (s *SwarmServiceCacheTestSuite) Test_InsertAndCheck_NewNodeInfo_ReturnsTrue
 	newSSMini := getNewSwarmServiceMini()
 	nodeSet := NodeIPSet{}
 	nodeSet.Add("node-3", "1.0.2.1")
-	newSSMini.NodeInfo = &nodeSet
+	newSSMini.NodeInfo = nodeSet
 
 	isUpdated = s.Cache.InsertAndCheck(newSSMini)
 	s.True(isUpdated)

--- a/service/swarmlistener.go
+++ b/service/swarmlistener.go
@@ -83,7 +83,7 @@ func NewSwarmListenerFromEnv(retries, interval int, logger *log.Logger) (*SwarmL
 		return nil, err
 	}
 	ssListener := NewSwarmServiceListener(dockerClient, logger)
-	ssClient := NewSwarmServiceClient(dockerClient, ignoreKey, "com.df.scrapeNetwork")
+	ssClient := NewSwarmServiceClient(dockerClient, ignoreKey, "com.df.scrapeNetwork", logger)
 	ssCache := NewSwarmServiceCache()
 
 	nodeListener := NewNodeListener(dockerClient, logger)

--- a/service/task.go
+++ b/service/task.go
@@ -1,0 +1,332 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+)
+
+// https://github.com/docker/cli/blob/master/cli/command/service/progress/progress.go
+// The same structure as `progress.go` without stdout
+
+var (
+	numberedStates = map[swarm.TaskState]int64{
+		swarm.TaskStateNew:       1,
+		swarm.TaskStateAllocated: 2,
+		swarm.TaskStatePending:   3,
+		swarm.TaskStateAssigned:  4,
+		swarm.TaskStateAccepted:  5,
+		swarm.TaskStatePreparing: 6,
+		swarm.TaskStateReady:     7,
+		swarm.TaskStateStarting:  8,
+		swarm.TaskStateRunning:   9,
+
+		// The following states are not actually shown in progress
+		// output, but are used internally for ordering.
+		swarm.TaskStateComplete: 10,
+		swarm.TaskStateShutdown: 11,
+		swarm.TaskStateFailed:   12,
+		swarm.TaskStateRejected: 13,
+	}
+
+	longestState int
+)
+
+func init() {
+	for state := range numberedStates {
+		if !terminalState(state) && len(state) > longestState {
+			longestState = len(state)
+		}
+	}
+}
+
+func terminalState(state swarm.TaskState) bool {
+	return numberedStates[state] > numberedStates[swarm.TaskStateRunning]
+}
+
+func stateToProgress(state swarm.TaskState, rollback bool) int64 {
+	if !rollback {
+		return numberedStates[state]
+	}
+	return numberedStates[swarm.TaskStateRunning] - numberedStates[state]
+}
+
+func getActiveNodes(ctx context.Context, client *client.Client) (map[string]struct{}, error) {
+	nodes, err := client.NodeList(ctx, types.NodeListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	activeNodes := make(map[string]struct{})
+	for _, n := range nodes {
+		if n.Status.State != swarm.NodeStateDown {
+			activeNodes[n.ID] = struct{}{}
+		}
+	}
+	return activeNodes, nil
+}
+
+func initializeUpdater(service swarm.Service) (progressUpdater, error) {
+	if service.Spec.Mode.Replicated != nil && service.Spec.Mode.Replicated.Replicas != nil {
+		return &replicatedProgressUpdater{}, nil
+	}
+	if service.Spec.Mode.Global != nil {
+		return &globalProgressUpdater{}, nil
+	}
+	return nil, errors.New("unrecognized service mode")
+}
+
+type progressUpdater interface {
+	update(service swarm.Service, tasks []swarm.Task, activeNodes map[string]struct{}, rollback bool) (bool, error)
+}
+
+// GetTaskList returns tasks when it is the service is converged
+func GetTaskList(ctx context.Context, client *client.Client, serviceID string) ([]swarm.Task, error) {
+
+	taskFilter := filters.NewArgs()
+	taskFilter.Add("service", serviceID)
+	taskFilter.Add("_up-to-date", "true")
+
+	getUpToDateTasks := func() ([]swarm.Task, error) {
+		return client.TaskList(ctx, types.TaskListOptions{Filters: taskFilter})
+	}
+
+	var (
+		updater     progressUpdater
+		converged   bool
+		convergedAt time.Time
+		monitor     = 5 * time.Second
+		rollback    bool
+	)
+
+	taskList := []swarm.Task{}
+
+	for {
+		service, _, err := client.ServiceInspectWithRaw(ctx, serviceID, types.ServiceInspectOptions{})
+		if err != nil {
+			return taskList, err
+		}
+
+		if service.Spec.UpdateConfig != nil && service.Spec.UpdateConfig.Monitor != 0 {
+			monitor = service.Spec.UpdateConfig.Monitor
+		}
+
+		if updater == nil {
+			updater, err = initializeUpdater(service)
+			if err != nil {
+				return taskList, err
+			}
+		}
+
+		if service.UpdateStatus != nil {
+			switch service.UpdateStatus.State {
+			case swarm.UpdateStateUpdating:
+				rollback = false
+			case swarm.UpdateStateCompleted:
+				if !converged {
+					return taskList, nil
+				}
+			case swarm.UpdateStatePaused:
+				return taskList, fmt.Errorf("service update paused: %s", service.UpdateStatus.Message)
+			case swarm.UpdateStateRollbackStarted:
+				rollback = true
+			case swarm.UpdateStateRollbackPaused:
+				return taskList, fmt.Errorf("service rollback paused %s", service.UpdateStatus.Message)
+			case swarm.UpdateStateRollbackCompleted:
+				if !converged {
+					return taskList, fmt.Errorf("service rolled back: %s", service.UpdateStatus.Message)
+				}
+			}
+		}
+		if converged && time.Since(convergedAt) >= monitor {
+			return taskList, nil
+		}
+
+		taskList, err = getUpToDateTasks()
+		if err != nil {
+			return taskList, err
+		}
+
+		activeNodes, err := getActiveNodes(ctx, client)
+		if err != nil {
+			return taskList, err
+		}
+
+		converged, err = updater.update(service, taskList, activeNodes, rollback)
+		if err != nil {
+			return taskList, err
+		}
+		if converged {
+			if convergedAt.IsZero() {
+				convergedAt = time.Now()
+			}
+		} else {
+			convergedAt = time.Time{}
+		}
+
+		<-time.After(200 * time.Millisecond)
+	}
+
+}
+
+type replicatedProgressUpdater struct {
+	initialized bool
+	done        bool
+}
+
+func (u *replicatedProgressUpdater) update(service swarm.Service, tasks []swarm.Task, activeNodes map[string]struct{}, rollback bool) (bool, error) {
+
+	if service.Spec.Mode.Replicated == nil || service.Spec.Mode.Replicated.Replicas == nil {
+		return false, errors.New("no replica count")
+	}
+
+	replicas := *service.Spec.Mode.Replicated.Replicas
+
+	if !u.initialized {
+		u.initialized = true
+	}
+
+	tasksBySlot := u.tasksBySlot(tasks, activeNodes)
+
+	// If we had reached a converged state, check if we are still converged.
+	if u.done {
+		for _, task := range tasksBySlot {
+			if task.Status.State != swarm.TaskStateRunning {
+				u.done = false
+				break
+			}
+		}
+	}
+
+	running := uint64(0)
+
+	for _, task := range tasksBySlot {
+		if !terminalState(task.DesiredState) && task.Status.State == swarm.TaskStateRunning {
+			running++
+		}
+	}
+
+	if !u.done && running == replicas {
+		u.done = true
+	}
+
+	return u.done == true, nil
+}
+
+func (u *replicatedProgressUpdater) tasksBySlot(tasks []swarm.Task, activeNodes map[string]struct{}) map[int]swarm.Task {
+	// If there are multiple tasks with the same slot number, favor the one
+	// with the *lowest* desired state. This can happen in restart
+	// scenarios.
+	tasksBySlot := make(map[int]swarm.Task)
+	for _, task := range tasks {
+		if numberedStates[task.DesiredState] == 0 || numberedStates[task.Status.State] == 0 {
+			continue
+		}
+		if existingTask, ok := tasksBySlot[task.Slot]; ok {
+			if numberedStates[existingTask.DesiredState] < numberedStates[task.DesiredState] {
+				continue
+			}
+			// If the desired states match, observed state breaks
+			// ties. This can happen with the "start first" service
+			// update mode.
+			if numberedStates[existingTask.DesiredState] == numberedStates[task.DesiredState] &&
+				numberedStates[existingTask.Status.State] <= numberedStates[task.Status.State] {
+				continue
+			}
+		}
+		if task.NodeID != "" {
+			if _, nodeActive := activeNodes[task.NodeID]; !nodeActive {
+				continue
+			}
+		}
+		tasksBySlot[task.Slot] = task
+	}
+
+	return tasksBySlot
+}
+
+type globalProgressUpdater struct {
+	initialized bool
+	done        bool
+}
+
+func (u *globalProgressUpdater) update(service swarm.Service, tasks []swarm.Task, activeNodes map[string]struct{}, rollback bool) (bool, error) {
+	tasksByNode := u.tasksByNode(tasks)
+	// We don't have perfect knowledge of how many nodes meet the
+	// constraints for this service. But the orchestrator creates tasks
+	// for all eligible nodes at the same time, so we should see all those
+	// nodes represented among the up-to-date tasks.
+	nodeCount := len(tasksByNode)
+
+	if !u.initialized {
+		if nodeCount == 0 {
+			// Two possibilities: either the orchestrator hasn't created
+			// the tasks yet, or the service doesn't meet constraints for
+			// any node. Either way, we wait.
+			return false, nil
+		}
+
+		u.initialized = true
+	}
+
+	// If we had reached a converged state, check if we are still converged.
+	if u.done {
+		for _, task := range tasksByNode {
+			if task.Status.State != swarm.TaskStateRunning {
+				u.done = false
+				break
+			}
+		}
+	}
+
+	running := 0
+
+	for _, task := range tasksByNode {
+		if _, nodeActive := activeNodes[task.NodeID]; nodeActive {
+			if !terminalState(task.DesiredState) && task.Status.State == swarm.TaskStateRunning {
+				running++
+			}
+		}
+	}
+
+	if !u.done && running == nodeCount {
+		u.done = true
+	}
+
+	return running == nodeCount, nil
+}
+
+func (u *globalProgressUpdater) tasksByNode(tasks []swarm.Task) map[string]swarm.Task {
+	// If there are multiple tasks with the same node ID, favor the one
+	// with the *lowest* desired state. This can happen in restart
+	// scenarios.
+	tasksByNode := make(map[string]swarm.Task)
+	for _, task := range tasks {
+		if numberedStates[task.DesiredState] == 0 || numberedStates[task.Status.State] == 0 {
+			continue
+		}
+		if existingTask, ok := tasksByNode[task.NodeID]; ok {
+			if numberedStates[existingTask.DesiredState] < numberedStates[task.DesiredState] {
+				continue
+			}
+
+			// If the desired states match, observed state breaks
+			// ties. This can happen with the "start first" service
+			// update mode.
+			if numberedStates[existingTask.DesiredState] == numberedStates[task.DesiredState] &&
+				numberedStates[existingTask.Status.State] <= numberedStates[task.Status.State] {
+				continue
+			}
+
+		}
+		tasksByNode[task.NodeID] = task
+	}
+
+	return tasksByNode
+}

--- a/service/task_test.go
+++ b/service/task_test.go
@@ -1,0 +1,256 @@
+package service
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/suite"
+)
+
+// https://github.com/docker/cli/blob/master/cli/command/service/progress/progress_test.go
+// Inspired by `progress_test.go`
+
+type TaskTestSuite struct {
+	suite.Suite
+	service     swarm.Service
+	updater     progressUpdater
+	activeNodes map[string]struct{}
+	rollback    bool
+}
+
+func TestTaskUnitTestSuite(t *testing.T) {
+	suite.Run(t, new(TaskTestSuite))
+}
+
+func (s *TaskTestSuite) Test_ReplicatedProcessUpdaterOneReplica() {
+	replicas := uint64(1)
+
+	service := swarm.Service{
+		Spec: swarm.ServiceSpec{
+			Mode: swarm.ServiceMode{
+				Replicated: &swarm.ReplicatedService{
+					Replicas: &replicas,
+				},
+			},
+		},
+	}
+
+	s.service = service
+	s.updater = new(replicatedProgressUpdater)
+	s.activeNodes = map[string]struct{}{"a": {}, "b": {}}
+
+	tasks := []swarm.Task{}
+
+	// No tasks
+	s.AssertConvergence(false, tasks)
+
+	// Tasks with DesiredState beyond running is not updated
+	tasks = append(tasks,
+		swarm.Task{ID: "1",
+			NodeID:       "a",
+			DesiredState: swarm.TaskStateShutdown,
+			Status:       swarm.TaskStatus{State: swarm.TaskStateNew},
+		})
+	s.AssertConvergence(false, tasks)
+
+	// First time task reaches TaskStateRunning, service has not updated yet
+	// The task is "new"
+	tasks[0].DesiredState = swarm.TaskStateRunning
+	s.AssertConvergence(false, tasks)
+
+	// When an error appears, service is not updated
+	tasks[0].Status.Err = "something is wrong"
+	s.AssertConvergence(false, tasks)
+
+	// When the tasks reaches running again, updated is true
+	tasks[0].Status.Err = ""
+	tasks[0].Status.State = swarm.TaskStateRunning
+	s.AssertConvergence(true, tasks)
+
+	// When tasks fails, update is false
+	tasks[0].Status.Err = "task failed"
+	tasks[0].Status.State = swarm.TaskStateFailed
+	s.AssertConvergence(false, tasks)
+
+	// If the task is restarted, update is true
+	tasks[0].DesiredState = swarm.TaskStateShutdown
+	tasks = append(tasks,
+		swarm.Task{
+			ID:           "2",
+			NodeID:       "b",
+			DesiredState: swarm.TaskStateRunning,
+			Status:       swarm.TaskStatus{State: swarm.TaskStateRunning},
+		})
+	s.AssertConvergence(true, tasks)
+
+	// Add a new task while the current one is still running, to simulate
+	// "start-then-stop" updates.
+	tasks = append(tasks,
+		swarm.Task{
+			ID:           "3",
+			NodeID:       "b",
+			DesiredState: swarm.TaskStateRunning,
+			Status:       swarm.TaskStatus{State: swarm.TaskStatePreparing},
+		})
+	s.AssertConvergence(false, tasks)
+
+}
+
+func (s *TaskTestSuite) Test_ReplicatedProcessUpdaterManyReplica() {
+	replicas := uint64(50)
+	service := swarm.Service{
+		Spec: swarm.ServiceSpec{
+			Mode: swarm.ServiceMode{
+				Replicated: &swarm.ReplicatedService{
+					Replicas: &replicas,
+				},
+			},
+		},
+	}
+
+	s.service = service
+	s.updater = new(replicatedProgressUpdater)
+	s.activeNodes = map[string]struct{}{"a": {}, "b": {}}
+
+	tasks := []swarm.Task{}
+
+	// No tasks
+	s.AssertConvergence(false, tasks)
+
+	for i := 0; i != int(replicas); i++ {
+		tasks = append(tasks,
+			swarm.Task{
+				ID:           strconv.Itoa(i),
+				Slot:         i + 1,
+				NodeID:       "a",
+				DesiredState: swarm.TaskStateRunning,
+				Status:       swarm.TaskStatus{State: swarm.TaskStateNew},
+			})
+		if i%2 == 1 {
+			tasks[i].NodeID = "b"
+		}
+		s.AssertConvergence(false, tasks)
+		tasks[i].Status.State = swarm.TaskStateRunning
+		s.AssertConvergence(uint64(i) == replicas-1, tasks)
+	}
+}
+
+func (s *TaskTestSuite) Test_GlobalProgressUpdaterOneNode() {
+
+	service := swarm.Service{
+		Spec: swarm.ServiceSpec{
+			Mode: swarm.ServiceMode{
+				Global: &swarm.GlobalService{},
+			},
+		},
+	}
+
+	s.activeNodes = map[string]struct{}{"a": {}, "b": {}}
+	s.service = service
+	s.updater = new(globalProgressUpdater)
+
+	tasks := []swarm.Task{}
+
+	// No tasks
+	s.AssertConvergence(false, tasks)
+
+	// Task with DesiredState beyond Running is ignored
+	tasks = append(tasks,
+		swarm.Task{
+			ID:           "1",
+			NodeID:       "a",
+			DesiredState: swarm.TaskStateShutdown,
+			Status:       swarm.TaskStatus{State: swarm.TaskStateNew},
+		})
+	s.AssertConvergence(false, tasks)
+
+	// First time task reaches TaskStateRunning, service has not converged yet
+	// The task is "new"
+	tasks[0].DesiredState = swarm.TaskStateRunning
+	s.AssertConvergence(false, tasks)
+
+	// If the task exposes an error, update is false
+	tasks[0].Status.Err = "something is wrong"
+	s.AssertConvergence(false, tasks)
+
+	// When the task reaches running, update is true
+	tasks[0].Status.Err = ""
+	tasks[0].Status.State = swarm.TaskStateRunning
+	s.AssertConvergence(true, tasks)
+
+	// If the task fails, update is false
+	tasks[0].Status.Err = "task failed"
+	tasks[0].Status.State = swarm.TaskStateFailed
+	s.AssertConvergence(false, tasks)
+
+	// If task is restarted, update is true
+	tasks[0].DesiredState = swarm.TaskStateShutdown
+	tasks = append(tasks,
+		swarm.Task{
+			ID:           "2",
+			NodeID:       "a",
+			DesiredState: swarm.TaskStateRunning,
+			Status:       swarm.TaskStatus{State: swarm.TaskStateRunning},
+		})
+	s.AssertConvergence(true, tasks)
+
+	tasks = append(tasks,
+		swarm.Task{
+			ID:           "3",
+			NodeID:       "a",
+			DesiredState: swarm.TaskStateRunning,
+			Status:       swarm.TaskStatus{State: swarm.TaskStatePreparing},
+		})
+	s.AssertConvergence(false, tasks)
+
+}
+
+func (s *TaskTestSuite) Test_GlobalProgressUpdaterManyNodes() {
+	nodes := 50
+
+	service := swarm.Service{
+		Spec: swarm.ServiceSpec{
+			Mode: swarm.ServiceMode{
+				Global: &swarm.GlobalService{},
+			},
+		},
+	}
+
+	s.service = service
+	s.updater = new(globalProgressUpdater)
+	s.activeNodes = map[string]struct{}{}
+
+	for i := 0; i != nodes; i++ {
+		s.activeNodes[strconv.Itoa(i)] = struct{}{}
+	}
+
+	tasks := []swarm.Task{}
+
+	// No tasks
+	s.AssertConvergence(false, tasks)
+
+	for i := 0; i != nodes; i++ {
+		tasks = append(tasks,
+			swarm.Task{
+				ID:           "task" + strconv.Itoa(i),
+				NodeID:       strconv.Itoa(i),
+				DesiredState: swarm.TaskStateRunning,
+				Status:       swarm.TaskStatus{State: swarm.TaskStateNew},
+			})
+	}
+	// All tasks are in "new" state
+	s.AssertConvergence(false, tasks)
+
+	for i := 0; i != nodes; i++ {
+		tasks[i].Status.State = swarm.TaskStateRunning
+		s.AssertConvergence(i == nodes-1, tasks)
+	}
+}
+
+func (s *TaskTestSuite) AssertConvergence(expectedConvergence bool, tasks []swarm.Task) {
+	converged, err := s.updater.update(
+		s.service, tasks, s.activeNodes, s.rollback)
+	s.Require().NoError(err)
+	s.Equal(expectedConvergence, converged)
+}

--- a/service/test_utils.go
+++ b/service/test_utils.go
@@ -156,7 +156,7 @@ func getNewSwarmServiceMini() SwarmServiceMini {
 		},
 		Replicas: uint64(3),
 		Global:   false,
-		NodeInfo: &nodeSet,
+		NodeInfo: nodeSet,
 	}
 }
 

--- a/service/types.go
+++ b/service/types.go
@@ -13,7 +13,7 @@ type SwarmServiceMini struct {
 	Labels   map[string]string
 	Global   bool
 	Replicas uint64
-	NodeInfo *NodeIPSet
+	NodeInfo NodeIPSet
 }
 
 // Equal returns when SwarmServiceMini is equal to `other`
@@ -69,7 +69,7 @@ func EqualMapStringString(l map[string]string, r map[string]string) bool {
 // SwarmService defines internal structure with service information
 type SwarmService struct {
 	swarm.Service
-	NodeInfo *NodeIPSet
+	NodeInfo NodeIPSet
 }
 
 // EventType is the type of event from eventlisteners
@@ -98,12 +98,12 @@ type NodeIP struct {
 type NodeIPSet map[NodeIP]struct{}
 
 // Add node to set
-func (ns *NodeIPSet) Add(name, addr string) {
-	(*ns)[NodeIP{Name: name, Addr: addr}] = struct{}{}
+func (ns NodeIPSet) Add(name, addr string) {
+	ns[NodeIP{Name: name, Addr: addr}] = struct{}{}
 }
 
 // EqualNodeIPSet returns true when NodeIPSets contain the same elements
-func EqualNodeIPSet(l *NodeIPSet, r *NodeIPSet) bool {
+func EqualNodeIPSet(l NodeIPSet, r NodeIPSet) bool {
 
 	if l == nil && r == nil {
 		return true
@@ -117,8 +117,8 @@ func EqualNodeIPSet(l *NodeIPSet, r *NodeIPSet) bool {
 		return false
 	}
 
-	for ip := range *l {
-		if _, ok := (*r)[ip]; !ok {
+	for ip := range l {
+		if _, ok := (r)[ip]; !ok {
 			return false
 		}
 	}

--- a/service/types_test.go
+++ b/service/types_test.go
@@ -65,19 +65,19 @@ func (s *TypesTestSuite) Test_Cardinality_RepeatElems() {
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_RepeatElems() {
-	a := &NodeIPSet{}
+	a := NodeIPSet{}
 	a.Add("node-1", "1.0.0.1")
 	a.Add("node-1", "1.0.0.1")
-	b := &NodeIPSet{}
+	b := NodeIPSet{}
 	b.Add("node-1", "1.0.0.1")
 	s.True(EqualNodeIPSet(a, b))
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_LenUnequal() {
-	a := &NodeIPSet{}
+	a := NodeIPSet{}
 	a.Add("node-1", "1.0.0.1")
 	a.Add("node-2", "1.0.1.1")
-	b := &NodeIPSet{}
+	b := NodeIPSet{}
 	b.Add("node-1", "1.0.0.1")
 	b.Add("node-2", "1.0.1.1")
 	b.Add("node-2", "1.0.1.2")
@@ -85,44 +85,44 @@ func (s *TypesTestSuite) Test_NodeIPSetEqual_LenUnequal() {
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_EqualSets() {
-	a := &NodeIPSet{}
+	a := NodeIPSet{}
 	a.Add("node-1", "1.0.0.1")
 	a.Add("node-2", "1.0.1.1")
-	b := &NodeIPSet{}
+	b := NodeIPSet{}
 	b.Add("node-1", "1.0.0.1")
 	b.Add("node-2", "1.0.1.1")
 	s.True(EqualNodeIPSet(a, b))
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_AddrNotEqual() {
-	a := &NodeIPSet{}
+	a := NodeIPSet{}
 	a.Add("node-1", "1.0.0.1")
 	a.Add("node-2", "1.0.1.1")
-	b := &NodeIPSet{}
+	b := NodeIPSet{}
 	b.Add("node-1", "1.0.0.1")
 	b.Add("node-2", "1.0.1.2")
 	s.False(EqualNodeIPSet(a, b))
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_NodeNameNotEqual() {
-	a := &NodeIPSet{}
+	a := NodeIPSet{}
 	a.Add("node-1", "1.0.0.1")
 	a.Add("node-2", "1.0.1.1")
-	b := &NodeIPSet{}
+	b := NodeIPSet{}
 	b.Add("node-1", "1.0.0.1")
 	b.Add("node-1", "1.0.1.1")
 	s.False(EqualNodeIPSet(a, b))
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_EmptySets() {
-	a := &NodeIPSet{}
-	b := &NodeIPSet{}
+	a := NodeIPSet{}
+	b := NodeIPSet{}
 	s.True(EqualNodeIPSet(a, b))
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_OneEmpty() {
-	a := &NodeIPSet{}
-	b := &NodeIPSet{}
+	a := NodeIPSet{}
+	b := NodeIPSet{}
 	b.Add("node-1", "1.0.0.1")
 	b.Add("node-1", "1.0.1.1")
 	s.False(EqualNodeIPSet(a, b))
@@ -137,13 +137,13 @@ func (s *TypesTestSuite) Test_NodeIPMarshallJSON_EmptySet() {
 }
 
 func (s *TypesTestSuite) Test_NodeIP_JSONCycle() {
-	a := &NodeIPSet{}
+	a := NodeIPSet{}
 	a.Add("node-1", "1.0.0.1")
 	a.Add("node-2", "1.0.1.1")
 	by, err := json.Marshal(a)
 	s.Require().NoError(err)
 
-	i := &NodeIPSet{}
+	i := NodeIPSet{}
 	err = json.Unmarshal(by, &i)
 	s.Require().NoError(err)
 
@@ -151,10 +151,10 @@ func (s *TypesTestSuite) Test_NodeIP_JSONCycle() {
 }
 
 func (s *TypesTestSuite) Test_NodeIPSet_Add() {
-	a := &NodeIPSet{}
+	a := NodeIPSet{}
 	a.Add("node-1", "1.0.0.1")
 	a.Add("node-1", "1.0.1.1")
-	b := &NodeIPSet{}
+	b := NodeIPSet{}
 	b.Add("node-1", "1.0.0.1")
 	b.Add("node-1", "1.0.1.1")
 


### PR DESCRIPTION
Two changes:

1. Waits for tasks to converge before querying for node info. Resolves [issue #38 from DFM](https://github.com/vfarcic/docker-flow-monitor/issues/38)
2. Small refactoring on NodeIPSet, by removing the pointer.