### PR TITLE
API: Adds node features

### DIFF
--- a/args.go
+++ b/args.go
@@ -6,7 +6,6 @@ import (
 )
 
 type args struct {
-	Interval      int
 	Retry         int
 	RetryInterval int
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ When a service is created or updated a notification will be sent to **[DF_NOTIFY
 |-------------|------------------------------------------------------------------------|---------|
 | serviceName | Name of service. If `com.df.shortName` is true, and the service is part of a stack the stack name will be trimed off. | `go-demo` |
 | replicas    | Number of replicas of service. If the service is global, this parameter will be excluded.| `3` |
-| nodeInfo    | An array of node with its ip on an overlay network. The network is defined with the label: `com.df.scrapeNetwork`. This parameter is included when environment variable, `DF_INCLUDE_NODE_IP_INFO`, is true. | `[["node-3","10.0.0.23"], ["node-2", "10.0.0.22"]]` |
+| nodeInfo    | An array of node with its ip on an overlay network. The network is defined with the label: `com.df.scrapeNetwork`. This parameter is included when environment variable, `DF_INCLUDE_NODE_IP_INFO`, is true. | `[["node-3","10.0.0.23", "node-3id"], ["node-2", "10.0.0.22", "node-2id"]]` |
 
 All service labels prefixed by `com.df.` will be added to the notification. For example, a service with label `com.df.hello=world` will translate to parameter: `hello=world`.
 
@@ -47,3 +47,7 @@ The *Get Services* endpoint is used to query all running services with the `DF_N
 ### Notify Services
 
 *DFSL* normally sends out notifcations when a service is created, updated, or removed. The *Notify Services* endpoint will force *DFSL* to send out notifications for all running services with the `DF_NOTIFY_LABEL` label. A `GET` request to **[SWARM_LISTENER_IP]:[SWARM_LISTENER_PORT]/v1/docker-flow-swarm-listener/notify-services** sends out the notifications.
+
+### Get Nodes
+
+The *Get Nodes* endpoint is used to query all nodes. A `GET` request to **[SWARM_LISTENER_IP]:[SWARM_LISTENER_PORT]/v1/docker-flow-swarm-listener/get-nodes** returns a json representation of these nodes.

--- a/serve.go
+++ b/serve.go
@@ -74,6 +74,27 @@ func (m *Serve) GetServices(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// GetNodes retrieves all nodes
+func (m *Serve) GetNodes(w http.ResponseWriter, req *http.Request) {
+	parameters, err := m.SwarmListener.GetNodesParameters(req.Context())
+	if err != nil {
+		m.Log.Printf("ERROR: Unable to prepare response: %s", err)
+		metrics.RecordError("serveGetNodes")
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	bytes, err := json.Marshal(parameters)
+	if err != nil {
+		m.Log.Printf("ERROR: Unable to prepare response: %s", err)
+		metrics.RecordError("serveGetNodes")
+		w.WriteHeader(http.StatusInternalServerError)
+	} else {
+		// NOTE: For an unknown reason, `httpWriterSetContentType` does not work so the header is set directly
+		w.Header().Set("Content-Type", "application/json")
+		httpWriterSetContentType(w, "application/json")
+		w.Write(bytes)
+	}
+}
+
 // PingHandler is used for health checks
 func (m *Serve) PingHandler(w http.ResponseWriter, req *http.Request) {
 	js, _ := json.Marshal(Response{Status: "OK"})

--- a/service/minify_test.go
+++ b/service/minify_test.go
@@ -94,8 +94,8 @@ func (s *MinifyUnitTestSuite) Test_MinifySwarmService_Global() {
 	}
 
 	nodeSet := NodeIPSet{}
-	nodeSet.Add("node-1", "1.0.0.1")
-	nodeSet.Add("node-2", "1.0.1.1")
+	nodeSet.Add("node-1", "1.0.0.1", "id1")
+	nodeSet.Add("node-2", "1.0.1.1", "id2")
 
 	service := swarm.Service{
 		ID:   "serviceID",
@@ -143,7 +143,7 @@ func (s *MinifyUnitTestSuite) Test_MinifySwarmService_Replicas() {
 	}
 
 	nodeSet := NodeIPSet{}
-	nodeSet.Add("node-1", "1.0.0.1")
+	nodeSet.Add("node-1", "1.0.0.1", "id1")
 
 	service := swarm.Service{
 		ID:   "serviceID",

--- a/service/service.go
+++ b/service/service.go
@@ -119,13 +119,13 @@ func (c SwarmServiceClient) getNodeInfo(ctx context.Context, ss swarm.Service) (
 		}
 
 		if nodeName, ok := nodeIPCache[task.NodeID]; ok {
-			nodeInfo.Add(nodeName, address)
+			nodeInfo.Add(nodeName, address, task.NodeID)
 		} else {
 			node, _, err := c.DockerClient.NodeInspectWithRaw(ctx, task.NodeID)
 			if err != nil {
 				continue
 			}
-			nodeInfo.Add(node.Description.Hostname, address)
+			nodeInfo.Add(node.Description.Hostname, address, task.NodeID)
 			nodeIPCache[task.NodeID] = node.Description.Hostname
 		}
 	}

--- a/service/servicecache_test.go
+++ b/service/servicecache_test.go
@@ -113,7 +113,7 @@ func (s *SwarmServiceCacheTestSuite) Test_InsertAndCheck_NewNodeInfo_ReturnsTrue
 
 	newSSMini := getNewSwarmServiceMini()
 	nodeSet := NodeIPSet{}
-	nodeSet.Add("node-3", "1.0.2.1")
+	nodeSet.Add("node-3", "1.0.2.1", "id3")
 	newSSMini.NodeInfo = nodeSet
 
 	isUpdated = s.Cache.InsertAndCheck(newSSMini)

--- a/service/swarmlistener.go
+++ b/service/swarmlistener.go
@@ -14,6 +14,7 @@ type SwarmListening interface {
 	NotifyServices(ignoreCache bool)
 	NotifyNodes(ignoreCache bool)
 	GetServicesParameters(ctx context.Context) ([]map[string]string, error)
+	GetNodesParameters(ctx context.Context) ([]map[string]string, error)
 }
 
 // SwarmListener provides public api
@@ -297,6 +298,23 @@ func (l SwarmListener) GetServicesParameters(ctx context.Context) ([]map[string]
 	for _, s := range services {
 		ssm := MinifySwarmService(s, l.IgnoreKey, l.IncludeKey)
 		newParams := GetSwarmServiceMiniCreateParameters(ssm)
+		if len(newParams) > 0 {
+			params = append(params, newParams)
+		}
+	}
+	return params, nil
+}
+
+// GetNodesParameters get all nodes
+func (l SwarmListener) GetNodesParameters(ctx context.Context) ([]map[string]string, error) {
+	nodes, err := l.NodeClient.NodeList(ctx)
+	if err != nil {
+		return []map[string]string{}, err
+	}
+	params := []map[string]string{}
+	for _, n := range nodes {
+		mn := MinifyNode(n)
+		newParams := GetNodeMiniCreateParameters(mn)
 		if len(newParams) > 0 {
 			params = append(params, newParams)
 		}

--- a/service/swarmlistener_test.go
+++ b/service/swarmlistener_test.go
@@ -368,3 +368,18 @@ func (s *WatcherTestSuite) Test_GetServices() {
 
 	s.SSClientMock.AssertExpectations(s.T())
 }
+
+func (s *WatcherTestSuite) Test_GetNodes() {
+
+	expServices := []swarm.Node{
+		swarm.Node{ID: "nodeID1"},
+		swarm.Node{ID: "nodeID2"},
+	}
+	s.NodeClientMock.On("NodeList", mock.AnythingOfType("*context.emptyCtx")).Return(expServices, nil)
+
+	params, err := s.SwarmListener.GetNodesParameters(context.Background())
+	s.Require().NoError(err)
+	s.Len(params, 2)
+
+	s.NodeClientMock.AssertExpectations(s.T())
+}

--- a/service/test_utils.go
+++ b/service/test_utils.go
@@ -146,7 +146,7 @@ func runDockerCommandOnSocket(args []string) (string, error) {
 
 func getNewSwarmServiceMini() SwarmServiceMini {
 	nodeSet := NodeIPSet{}
-	nodeSet.Add("node-1", "1.0.0.1")
+	nodeSet.Add("node-1", "1.0.0.1", "id1")
 
 	return SwarmServiceMini{
 		ID:   "serviceID",

--- a/service/types.go
+++ b/service/types.go
@@ -92,14 +92,15 @@ type Event struct {
 type NodeIP struct {
 	Name string `json:"name"`
 	Addr string `json:"addr"`
+	ID   string `json:"id"`
 }
 
 // NodeIPSet is a set of NodeIPs
 type NodeIPSet map[NodeIP]struct{}
 
 // Add node to set
-func (ns NodeIPSet) Add(name, addr string) {
-	ns[NodeIP{Name: name, Addr: addr}] = struct{}{}
+func (ns NodeIPSet) Add(name, addr, id string) {
+	ns[NodeIP{Name: name, Addr: addr, ID: id}] = struct{}{}
 }
 
 // EqualNodeIPSet returns true when NodeIPSets contain the same elements
@@ -132,10 +133,10 @@ func (ns NodeIPSet) Cardinality() int {
 
 // MarshalJSON creates JSON array from NodeIPSet
 func (ns NodeIPSet) MarshalJSON() ([]byte, error) {
-	items := make([][2]string, 0, ns.Cardinality())
+	items := make([][]string, 0, ns.Cardinality())
 
 	for elem := range ns {
-		items = append(items, [2]string{elem.Name, elem.Addr})
+		items = append(items, []string{elem.Name, elem.Addr, elem.ID})
 	}
 	return json.Marshal(items)
 }
@@ -143,14 +144,18 @@ func (ns NodeIPSet) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON recreates NodeIPSet from a JSON array
 func (ns *NodeIPSet) UnmarshalJSON(b []byte) error {
 
-	items := [][2]string{}
+	items := [][]string{}
 	err := json.Unmarshal(b, &items)
 	if err != nil {
 		return err
 	}
 
 	for _, item := range items {
-		(*ns)[NodeIP{Name: item[0], Addr: item[1]}] = struct{}{}
+		nodeIP := NodeIP{Name: item[0], Addr: item[1]}
+		if len(item) == 3 {
+			nodeIP.ID = item[2]
+		}
+		(*ns)[nodeIP] = struct{}{}
 	}
 
 	return nil

--- a/service/types_test.go
+++ b/service/types_test.go
@@ -52,65 +52,65 @@ func (s *TypesTestSuite) Test_EqualMapStringString_DifferentNumberOfValues() {
 
 func (s *TypesTestSuite) Test_Cardinality_DifferentElms() {
 	a := NodeIPSet{}
-	a.Add("node-1", "1.0.0.1")
-	a.Add("node-2", "1.0.1.1")
+	a.Add("node-1", "1.0.0.1", "id1")
+	a.Add("node-2", "1.0.1.1", "id2")
 	s.Equal(2, a.Cardinality())
 }
 
 func (s *TypesTestSuite) Test_Cardinality_RepeatElems() {
 	a := NodeIPSet{}
-	a.Add("node-1", "1.0.0.1")
-	a.Add("node-1", "1.0.0.1")
+	a.Add("node-1", "1.0.0.1", "id1")
+	a.Add("node-1", "1.0.0.1", "id1")
 	s.Equal(1, a.Cardinality())
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_RepeatElems() {
 	a := NodeIPSet{}
-	a.Add("node-1", "1.0.0.1")
-	a.Add("node-1", "1.0.0.1")
+	a.Add("node-1", "1.0.0.1", "id1")
+	a.Add("node-1", "1.0.0.1", "id1")
 	b := NodeIPSet{}
-	b.Add("node-1", "1.0.0.1")
+	b.Add("node-1", "1.0.0.1", "id1")
 	s.True(EqualNodeIPSet(a, b))
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_LenUnequal() {
 	a := NodeIPSet{}
-	a.Add("node-1", "1.0.0.1")
-	a.Add("node-2", "1.0.1.1")
+	a.Add("node-1", "1.0.0.1", "id1")
+	a.Add("node-2", "1.0.1.1", "id2")
 	b := NodeIPSet{}
-	b.Add("node-1", "1.0.0.1")
-	b.Add("node-2", "1.0.1.1")
-	b.Add("node-2", "1.0.1.2")
+	b.Add("node-1", "1.0.0.1", "id1")
+	b.Add("node-2", "1.0.1.1", "id2")
+	b.Add("node-2", "1.0.1.2", "id2")
 	s.False(EqualNodeIPSet(a, b))
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_EqualSets() {
 	a := NodeIPSet{}
-	a.Add("node-1", "1.0.0.1")
-	a.Add("node-2", "1.0.1.1")
+	a.Add("node-1", "1.0.0.1", "id1")
+	a.Add("node-2", "1.0.1.1", "id2")
 	b := NodeIPSet{}
-	b.Add("node-1", "1.0.0.1")
-	b.Add("node-2", "1.0.1.1")
+	b.Add("node-1", "1.0.0.1", "id1")
+	b.Add("node-2", "1.0.1.1", "id2")
 	s.True(EqualNodeIPSet(a, b))
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_AddrNotEqual() {
 	a := NodeIPSet{}
-	a.Add("node-1", "1.0.0.1")
-	a.Add("node-2", "1.0.1.1")
+	a.Add("node-1", "1.0.0.1", "id1")
+	a.Add("node-2", "1.0.1.1", "id2")
 	b := NodeIPSet{}
-	b.Add("node-1", "1.0.0.1")
-	b.Add("node-2", "1.0.1.2")
+	b.Add("node-1", "1.0.0.1", "id1")
+	b.Add("node-2", "1.0.1.2", "id2")
 	s.False(EqualNodeIPSet(a, b))
 }
 
 func (s *TypesTestSuite) Test_NodeIPSetEqual_NodeNameNotEqual() {
 	a := NodeIPSet{}
-	a.Add("node-1", "1.0.0.1")
-	a.Add("node-2", "1.0.1.1")
+	a.Add("node-1", "1.0.0.1", "id1")
+	a.Add("node-2", "1.0.1.1", "id2")
 	b := NodeIPSet{}
-	b.Add("node-1", "1.0.0.1")
-	b.Add("node-1", "1.0.1.1")
+	b.Add("node-1", "1.0.0.1", "id1")
+	b.Add("node-1", "1.0.1.1", "id1")
 	s.False(EqualNodeIPSet(a, b))
 }
 
@@ -123,8 +123,8 @@ func (s *TypesTestSuite) Test_NodeIPSetEqual_EmptySets() {
 func (s *TypesTestSuite) Test_NodeIPSetEqual_OneEmpty() {
 	a := NodeIPSet{}
 	b := NodeIPSet{}
-	b.Add("node-1", "1.0.0.1")
-	b.Add("node-1", "1.0.1.1")
+	b.Add("node-1", "1.0.0.1", "id1")
+	b.Add("node-1", "1.0.1.1", "id1")
 	s.False(EqualNodeIPSet(a, b))
 }
 
@@ -138,8 +138,8 @@ func (s *TypesTestSuite) Test_NodeIPMarshallJSON_EmptySet() {
 
 func (s *TypesTestSuite) Test_NodeIP_JSONCycle() {
 	a := NodeIPSet{}
-	a.Add("node-1", "1.0.0.1")
-	a.Add("node-2", "1.0.1.1")
+	a.Add("node-1", "1.0.0.1", "id1")
+	a.Add("node-2", "1.0.1.1", "id2")
 	by, err := json.Marshal(a)
 	s.Require().NoError(err)
 
@@ -152,11 +152,21 @@ func (s *TypesTestSuite) Test_NodeIP_JSONCycle() {
 
 func (s *TypesTestSuite) Test_NodeIPSet_Add() {
 	a := NodeIPSet{}
-	a.Add("node-1", "1.0.0.1")
-	a.Add("node-1", "1.0.1.1")
+	a.Add("node-1", "1.0.0.1", "id1")
+	a.Add("node-1", "1.0.1.1", "id1")
 	b := NodeIPSet{}
-	b.Add("node-1", "1.0.0.1")
-	b.Add("node-1", "1.0.1.1")
+	b.Add("node-1", "1.0.0.1", "id1")
+	b.Add("node-1", "1.0.1.1", "id1")
 
 	s.True(EqualNodeIPSet(a, b))
+}
+
+func (s *TypesTestSuite) Test_NodeIP_WithTwoEntries() {
+	nodeBytes := []byte("[[\"node-1\", \"1.0.0.1\"], [\"node-2\", \"1.0.1.1\"]]")
+	ipSet := NodeIPSet{}
+	err := json.Unmarshal(nodeBytes, &ipSet)
+	s.Require().NoError(err)
+
+	s.Contains(ipSet, NodeIP{Name: "node-1", Addr: "1.0.0.1"})
+	s.Contains(ipSet, NodeIP{Name: "node-2", Addr: "1.0.1.1"})
 }


### PR DESCRIPTION
1. Adds node ID to `nodeInfo`. 
2. Adds endpoint `/v1/docker-flow-swarm-listener/get-nodes` to get all nodes.

Both of these features are used to resolve https://github.com/vfarcic/docker-flow-monitor/issues/42.