### PR TITLE
ENH: Always wait for services to converge

### DIFF
--- a/service/cancelmanager.go
+++ b/service/cancelmanager.go
@@ -8,7 +8,8 @@ import (
 // CancelManaging manages canceling of contexts
 type CancelManaging interface {
 	Add(id string, reqID int64) context.Context
-	Delete(id string, reqID int64)
+	Delete(id string, reqID int64) bool
+	ForceDelete(id string) bool
 }
 
 type cancelPair struct {
@@ -58,23 +59,41 @@ func (m *CancelManager) Add(id string, reqID int64) context.Context {
 
 // Delete calls cancel on context with the corresponding `id` and `reqID` and remove 'id'
 // from memory If the corresponding `id` and `reqID` are not present, Delete does nothing.
-func (m *CancelManager) Delete(id string, reqID int64) {
+// Returns true if item was deleted
+func (m *CancelManager) Delete(id string, reqID int64) bool {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
 	pair, ok := m.v[id]
 
 	if !ok || pair.ReqID != reqID {
-		return
+		return false
 	}
 
 	pair.Cnt = pair.Cnt - 1
 
 	if pair.Cnt != 0 {
 		m.v[id] = pair
-		return
+		return false
 	}
 
 	pair.Cancel()
 	delete(m.v, id)
+	return true
+}
+
+// ForceDelete deletes an id without looking at the `reqID` and count
+func (m *CancelManager) ForceDelete(id string) bool {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	pair, ok := m.v[id]
+
+	if !ok {
+		return false
+	}
+
+	pair.Cancel()
+	delete(m.v, id)
+	return true
 }

--- a/service/mocks.go
+++ b/service/mocks.go
@@ -40,8 +40,14 @@ func (m *cancelManagingMock) Add(id string, reqID int64) context.Context {
 	return args.Get(0).(context.Context)
 }
 
-func (m *cancelManagingMock) Delete(id string, reqID int64) {
-	m.Called(id, reqID)
+func (m *cancelManagingMock) Delete(id string, reqID int64) bool {
+	args := m.Called(id, reqID)
+	return args.Bool(0)
+}
+
+func (m *cancelManagingMock) ForceDelete(id string) bool {
+	args := m.Called(id)
+	return args.Bool(0)
 }
 
 type swarmServiceListeningMock struct {
@@ -56,8 +62,8 @@ type swarmServiceInspector struct {
 	mock.Mock
 }
 
-func (m *swarmServiceInspector) SwarmServiceInspect(serviceID string, includeNodeIPInfo bool) (*SwarmService, error) {
-	args := m.Called(serviceID, includeNodeIPInfo)
+func (m *swarmServiceInspector) SwarmServiceInspect(ctx context.Context, serviceID string, includeNodeIPInfo bool) (*SwarmService, error) {
+	args := m.Called(ctx, serviceID, includeNodeIPInfo)
 	return args.Get(0).(*SwarmService), args.Error(1)
 }
 

--- a/service/notifydistributor_test.go
+++ b/service/notifydistributor_test.go
@@ -295,7 +295,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 		On("Add", "sid2", mock.AnythingOfType("int64")).
 		Return(context.Background()).
 		On("Delete", "sid1", mock.AnythingOfType("int64")).
-		Return(context.Background()).
+		Return(true).
 		Run(func(args mock.Arguments) {
 			deleteCnt1++
 			if deleteCnt1 == 2 {
@@ -303,7 +303,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 			}
 		}).
 		On("Delete", "sid2", mock.AnythingOfType("int64")).
-		Return(context.Background()).
+		Return(true).
 		Run(func(args mock.Arguments) {
 			deleteCnt2++
 			if deleteCnt2 == 2 {
@@ -394,7 +394,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 		On("Add", "nid2", mock.AnythingOfType("int64")).
 		Return(context.Background()).
 		On("Delete", "nid1", mock.AnythingOfType("int64")).
-		Return(context.Background()).
+		Return(true).
 		Run(func(args mock.Arguments) {
 			deleteCnt1++
 			if deleteCnt1 == 2 {
@@ -402,7 +402,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 			}
 		}).
 		On("Delete", "nid2", mock.AnythingOfType("int64")).
-		Return(context.Background()).
+		Return(true).
 		Run(func(args mock.Arguments) {
 			deleteCnt2++
 			if deleteCnt2 == 2 {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -68,7 +68,7 @@ func (s *SwarmServiceClientTestSuite) TearDownSuite() {
 
 func (s *SwarmServiceClientTestSuite) Test_SwarmServiceInspect_NodeInfo_UndefinedScrapeNetwork() {
 
-	util3Service, err := s.SClient.SwarmServiceInspect(s.Util3ID, true)
+	util3Service, err := s.SClient.SwarmServiceInspect(context.Background(), s.Util3ID, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(util3Service)
 
@@ -78,14 +78,14 @@ func (s *SwarmServiceClientTestSuite) Test_SwarmServiceInspect_NodeInfo_Undefine
 
 func (s *SwarmServiceClientTestSuite) Test_ServiceList_Filtered() {
 
-	util2Service, err := s.SClient.SwarmServiceInspect(s.Util2ID, false)
+	util2Service, err := s.SClient.SwarmServiceInspect(context.Background(), s.Util2ID, false)
 	s.Require().NoError(err)
 	s.Nil(util2Service)
 
 }
 
 func (s *SwarmServiceClientTestSuite) Test_SwarmServiceInspect_NodeInfo_OneReplica() {
-	util1Service, err := s.SClient.SwarmServiceInspect(s.Util1ID, true)
+	util1Service, err := s.SClient.SwarmServiceInspect(context.Background(), s.Util1ID, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(util1Service)
 
@@ -98,7 +98,7 @@ func (s *SwarmServiceClientTestSuite) Test_SwarmServiceInspect_NodeInfo_OneRepli
 
 func (s *SwarmServiceClientTestSuite) Test_SwarmServiceInspect_NodeInfo_TwoReplica() {
 
-	util4Service, err := s.SClient.SwarmServiceInspect(s.Util4ID, true)
+	util4Service, err := s.SClient.SwarmServiceInspect(context.Background(), s.Util4ID, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(util4Service)
 
@@ -110,7 +110,7 @@ func (s *SwarmServiceClientTestSuite) Test_SwarmServiceInspect_NodeInfo_TwoRepli
 }
 
 func (s *SwarmServiceClientTestSuite) Test_SwarmServiceInspect_IncorrectName() {
-	_, err := s.SClient.SwarmServiceInspect("cowsfly", true)
+	_, err := s.SClient.SwarmServiceInspect(context.Background(), "cowsfly", true)
 	s.Error(err)
 }
 


### PR DESCRIPTION
Closes https://github.com/vfarcic/docker-flow-proxy/issues/453

1. I think always waiting for services to converge is a good default. This way create notifications will be sent out when the services are up and running.

2. While DFSL is waiting for a service to go through, all other notifications (not related to the waiting service) will still be sent through. This correctly represents the state of the swarm.

3. When DFSL is waiting for a service to converge, and another event related to that service to received, DFSL will cancel waiting for that service and process the new event instead.