### PR TITLE
ENH: More robust handling of events

### DIFF
--- a/service/cancelmanager.go
+++ b/service/cancelmanager.go
@@ -58,9 +58,10 @@ func (m *CancelManager) Add(id string, reqID int64) context.Context {
 	return ctx
 }
 
-// Delete calls cancel on context with the corresponding `id` and `reqID` and remove 'id'
-// from memory If the corresponding `id` and `reqID` are not present, Delete does nothing.
-// Returns true if item was deleted
+// Delete calls cancel context with the corresponding `id` and `reqID` and
+// removes 'id' from map
+// If the corresponding `id` and `reqID` are not present, Delete does nothing.
+// In all cases, Delete returns true if an item was deleted
 func (m *CancelManager) Delete(id string, reqID int64) bool {
 	m.mux.Lock()
 	defer m.mux.Unlock()

--- a/service/eventnodelistener.go
+++ b/service/eventnodelistener.go
@@ -50,8 +50,9 @@ func (s NodeListener) ListenForNodeEvents(
 					eventType = EventTypeRemove
 				}
 				eventChan <- Event{
-					Type: eventType,
-					ID:   msg.Actor.ID,
+					Type:     eventType,
+					ID:       msg.Actor.ID,
+					TimeNano: msg.TimeNano,
 				}
 			case err := <-msgErrs:
 				s.log.Printf("%v, Restarting docker event stream", err)

--- a/service/eventservicelistener.go
+++ b/service/eventservicelistener.go
@@ -47,8 +47,9 @@ func (s SwarmServiceListener) ListenForServiceEvents(eventChan chan<- Event) {
 					eventType = EventTypeRemove
 				}
 				eventChan <- Event{
-					Type: eventType,
-					ID:   msg.Actor.ID,
+					Type:     eventType,
+					ID:       msg.Actor.ID,
+					TimeNano: msg.TimeNano,
 				}
 			case err := <-msgErrs:
 				s.log.Printf("%v, Restarting docker event stream", err)

--- a/service/notifydistributor_test.go
+++ b/service/notifydistributor_test.go
@@ -290,11 +290,11 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 	serviceNotifyMock2.On("Remove", mock.AnythingOfType("*context.emptyCtx"), "hello=world2").
 		Return(nil)
 	serviceCancelManagerMock := new(cancelManagingMock)
-	serviceCancelManagerMock.On("Add", "sid1", mock.AnythingOfType("int64")).
+	serviceCancelManagerMock.On("Add", "sid1", int64(1)).
 		Return(context.Background()).
-		On("Add", "sid2", mock.AnythingOfType("int64")).
+		On("Add", "sid2", int64(2)).
 		Return(context.Background()).
-		On("Delete", "sid1", mock.AnythingOfType("int64")).
+		On("Delete", "sid1", int64(1)).
 		Return(true).
 		Run(func(args mock.Arguments) {
 			deleteCnt1++
@@ -302,7 +302,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 				serviceCancel1 <- struct{}{}
 			}
 		}).
-		On("Delete", "sid2", mock.AnythingOfType("int64")).
+		On("Delete", "sid2", int64(2)).
 		Return(true).
 		Run(func(args mock.Arguments) {
 			deleteCnt2++
@@ -338,6 +338,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 			EventType:  EventTypeCreate,
 			ID:         "sid1",
 			Parameters: "hello=world",
+			TimeNano:   int64(1),
 		}
 	}()
 	go func() {
@@ -345,6 +346,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 			EventType:  EventTypeRemove,
 			ID:         "sid2",
 			Parameters: "hello=world2",
+			TimeNano:   int64(2),
 		}
 	}()
 
@@ -389,11 +391,11 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 		Return(nil)
 	serviceCancelManagerMock := new(cancelManagingMock)
 	nodeCancelManagerMock := new(cancelManagingMock)
-	nodeCancelManagerMock.On("Add", "nid1", mock.AnythingOfType("int64")).
+	nodeCancelManagerMock.On("Add", "nid1", int64(1)).
 		Return(context.Background()).
-		On("Add", "nid2", mock.AnythingOfType("int64")).
+		On("Add", "nid2", int64(2)).
 		Return(context.Background()).
-		On("Delete", "nid1", mock.AnythingOfType("int64")).
+		On("Delete", "nid1", int64(1)).
 		Return(true).
 		Run(func(args mock.Arguments) {
 			deleteCnt1++
@@ -401,7 +403,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 				nodeCancel1 <- struct{}{}
 			}
 		}).
-		On("Delete", "nid2", mock.AnythingOfType("int64")).
+		On("Delete", "nid2", int64(2)).
 		Return(true).
 		Run(func(args mock.Arguments) {
 			deleteCnt2++
@@ -436,6 +438,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 			EventType:  EventTypeCreate,
 			ID:         "nid1",
 			Parameters: "hello=world",
+			TimeNano:   int64(1),
 		}
 	}()
 	go func() {
@@ -443,6 +446,7 @@ func (s *NotifyDistributorTestSuite) Test_RunDistributesNotificationsToEndpoints
 			EventType:  EventTypeRemove,
 			ID:         "nid2",
 			Parameters: "hello=world2",
+			TimeNano:   int64(2),
 		}
 	}()
 

--- a/service/types.go
+++ b/service/types.go
@@ -84,8 +84,9 @@ const (
 
 // Event contains information about docker events
 type Event struct {
-	Type EventType
-	ID   string
+	Type     EventType
+	ID       string
+	TimeNano int64
 }
 
 // NodeIP defines a node/addr pair


### PR DESCRIPTION
1. Use docker event timestamp as request ID along with serviceID, or nodeID
2. Create events can cancel remove events and vice versa