### PR TITLE
ENH: More robust event handling

### DIFF
--- a/service/cancelmanager.go
+++ b/service/cancelmanager.go
@@ -7,7 +7,7 @@ import (
 
 // CancelManaging manages canceling of contexts
 type CancelManaging interface {
-	Add(id string, reqID int64) context.Context
+	Add(rootCtx context.Context, id string, reqID int64) context.Context
 	Delete(id string, reqID int64) bool
 	ForceDelete(id string) bool
 }
@@ -15,31 +15,27 @@ type CancelManaging interface {
 type cancelPair struct {
 	Cancel context.CancelFunc
 	ReqID  int64
-	Cnt    int
 }
 
 // CancelManager implements the `CancelManaging` interface that is thread safe
 type CancelManager struct {
 	v                  map[string]cancelPair
 	mux                sync.Mutex
-	startingCnt        int
 	cancelBeforeAdding bool
 }
 
 // NewCancelManager creates a new `CancelManager`
-// `startingCnt` is the number of expected request to send out
-func NewCancelManager(startingCnt int, cancelBeforeAdding bool) *CancelManager {
+func NewCancelManager(cancelBeforeAdding bool) *CancelManager {
 	return &CancelManager{
 		v:                  map[string]cancelPair{},
 		mux:                sync.Mutex{},
-		startingCnt:        startingCnt,
 		cancelBeforeAdding: cancelBeforeAdding,
 	}
 }
 
 // Add creates an context for `id` and `reqID` and returns that context.
 // If `id` exists in memory and cancelBeforeAdding is true, the task with that `id` will be canceled.
-func (m *CancelManager) Add(id string, reqID int64) context.Context {
+func (m *CancelManager) Add(rootCtx context.Context, id string, reqID int64) context.Context {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
@@ -49,11 +45,10 @@ func (m *CancelManager) Add(id string, reqID int64) context.Context {
 		delete(m.v, id)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(rootCtx)
 	m.v[id] = cancelPair{
 		Cancel: cancel,
 		ReqID:  reqID,
-		Cnt:    m.startingCnt,
 	}
 	return ctx
 }
@@ -69,13 +64,6 @@ func (m *CancelManager) Delete(id string, reqID int64) bool {
 	pair, ok := m.v[id]
 
 	if !ok || pair.ReqID != reqID {
-		return false
-	}
-
-	pair.Cnt = pair.Cnt - 1
-
-	if pair.Cnt != 0 {
-		m.v[id] = pair
 		return false
 	}
 

--- a/service/cancelmanager_test.go
+++ b/service/cancelmanager_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,16 +10,21 @@ import (
 
 type CancelManagerTestSuite struct {
 	suite.Suite
+	ctx context.Context
 }
 
 func TestCancelManagerUnitTestSuite(t *testing.T) {
 	suite.Run(t, new(CancelManagerTestSuite))
 }
 
+func (s *CancelManagerTestSuite) SetupSuite() {
+	s.ctx = context.Background()
+}
+
 func (s *CancelManagerTestSuite) Test_Add_IDEqual_CancelsContext_Returns_Context() {
-	cm := NewCancelManager(1, true)
-	ctx := cm.Add("id1", 1)
-	cm.Add("id1", 2)
+	cm := NewCancelManager(true)
+	ctx := cm.Add(s.ctx, "id1", 1)
+	cm.Add(s.ctx, "id1", 2)
 
 L:
 	for {
@@ -31,14 +37,13 @@ L:
 		}
 	}
 
-	s.Equal(1, cm.v["id1"].Cnt)
 	s.Equal(int64(2), cm.v["id1"].ReqID)
 }
 
 func (s *CancelManagerTestSuite) Test_Add_IDNotExist_Returns_Context() {
 
-	cm := NewCancelManager(1, true)
-	firstCtx := cm.Add("id1", 1)
+	cm := NewCancelManager(true)
+	firstCtx := cm.Add(s.ctx, "id1", 1)
 	s.NotNil(firstCtx)
 
 	s.Require().Contains(cm.v, "id1")
@@ -46,8 +51,8 @@ func (s *CancelManagerTestSuite) Test_Add_IDNotExist_Returns_Context() {
 }
 
 func (s *CancelManagerTestSuite) Test_Delete_IDEqual_ReqIDNotEqual_DoesNothing() {
-	cm := NewCancelManager(1, true)
-	cm.Add("id1", 1)
+	cm := NewCancelManager(true)
+	cm.Add(s.ctx, "id1", 1)
 
 	s.Require().Len(cm.v, 1)
 
@@ -58,8 +63,8 @@ func (s *CancelManagerTestSuite) Test_Delete_IDEqual_ReqIDNotEqual_DoesNothing()
 }
 
 func (s *CancelManagerTestSuite) Test_Delete_IDEqual_ReqIDEqual_CallsCancel_RemovesFromMemory() {
-	cm := NewCancelManager(1, true)
-	ctx := cm.Add("id1", 1)
+	cm := NewCancelManager(true)
+	ctx := cm.Add(s.ctx, "id1", 1)
 
 	s.Require().Len(cm.v, 1)
 
@@ -80,25 +85,18 @@ L:
 
 func (s *CancelManagerTestSuite) Test_Delete_IDEqual_ReqIDEqual_CntNotZero_StaysInMemory() {
 	// Set startingCnt to 2
-	cm := NewCancelManager(2, true)
-	cm.Add("id1", 1)
+	cm := NewCancelManager(true)
+	cm.Add(s.ctx, "id1", 1)
 	s.Require().Len(cm.v, 1)
 	s.Require().Contains(cm.v, "id1")
-	s.Equal(2, cm.v["id1"].Cnt)
-
-	// Cnt is now at one
-	s.False(cm.Delete("id1", 1))
-	s.Require().Len(cm.v, 1)
-	s.Require().Contains(cm.v, "id1")
-	s.Equal(1, cm.v["id1"].Cnt)
 
 	s.True(cm.Delete("id1", 1))
 	s.Require().Len(cm.v, 0)
 }
 
 func (s *CancelManagerTestSuite) Test_ForceDelete() {
-	cm := NewCancelManager(2, true)
-	ctx := cm.Add("id1", 1)
+	cm := NewCancelManager(true)
+	ctx := cm.Add(s.ctx, "id1", 1)
 	s.Require().Len(cm.v, 1)
 
 	s.False(cm.ForceDelete("DOESNOTEXIST"))

--- a/service/mocks.go
+++ b/service/mocks.go
@@ -31,25 +31,6 @@ func (m *notificationSenderMock) GetRemoveAddr() string {
 	return args.String(0)
 }
 
-type cancelManagingMock struct {
-	mock.Mock
-}
-
-func (m *cancelManagingMock) Add(id string, reqID int64) context.Context {
-	args := m.Called(id, reqID)
-	return args.Get(0).(context.Context)
-}
-
-func (m *cancelManagingMock) Delete(id string, reqID int64) bool {
-	args := m.Called(id, reqID)
-	return args.Bool(0)
-}
-
-func (m *cancelManagingMock) ForceDelete(id string) bool {
-	args := m.Called(id)
-	return args.Bool(0)
-}
-
 type swarmServiceListeningMock struct {
 	mock.Mock
 }


### PR DESCRIPTION
1. Events that are canceled will also cancel older pending notifications with the same serviceID or nodeID.
2. The processing of an event will be completed when all notifications are sent out or the event is canceled by another event.
3. Reduces the complexity of CancelManager.